### PR TITLE
feat(sdk): support scoped AWS credentials for discovery clients

### DIFF
--- a/.changeset/aws-credentials-passthrough.md
+++ b/.changeset/aws-credentials-passthrough.md
@@ -2,4 +2,4 @@
 '@cloudburn/sdk': minor
 ---
 
-Add scoped AWS credentials support for live discovery. `CloudBurnClient.discover()` accepts `aws.credentials` (a static identity or credential provider), and the new `withAwsClientCredentials()` helper scopes credentials to every AWS client created inside a callback. All client factories also accept explicit `credentials`. Existing behavior is unchanged when no credentials are supplied.
+Add scoped AWS credentials support for live discovery. `CloudBurnClient.discover()` accepts `aws.credentials` (a static identity or credential provider), and the new `withAwsClientCredentials()` helper scopes credentials to every AWS client created inside a callback. Existing behavior is unchanged when no credentials are supplied.

--- a/.changeset/aws-credentials-passthrough.md
+++ b/.changeset/aws-credentials-passthrough.md
@@ -1,0 +1,5 @@
+---
+'@cloudburn/sdk': minor
+---
+
+Add scoped AWS credentials support for live discovery. `CloudBurnClient.discover()` accepts `aws.credentials` (a static identity or credential provider), and the new `withAwsClientCredentials()` helper scopes credentials to every AWS client created inside a callback. All client factories also accept explicit `credentials`. Existing behavior is unchanged when no credentials are supplied.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -69,6 +69,7 @@
     "@aws-sdk/client-sagemaker": "^3.1019.0",
     "@aws-sdk/client-secrets-manager": "^3.1015.0",
     "@aws-sdk/client-sts": "^3.1003.0",
+    "@aws-sdk/types": "^3.973.6",
     "@cdktf/hcl2json": "^0.21.0",
     "@cloudburn/rules": "workspace:*",
     "yaml": "^2.8.2"

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,7 +3,12 @@
 export { awsCorePreset } from '@cloudburn/rules';
 export { builtInRuleMetadata } from './built-in-rules.js';
 export { parseIaC } from './parsers/index.js';
-export { assertSupportedAwsRegion, assertValidAwsRegion } from './providers/aws/client.js';
+export {
+  type AwsClientCredentials,
+  assertSupportedAwsRegion,
+  assertValidAwsRegion,
+  withAwsClientCredentials,
+} from './providers/aws/client.js';
 export { isAwsDiscoveryErrorCode } from './providers/aws/errors.js';
 export { CloudBurnClient } from './scanner.js';
 export type {

--- a/packages/sdk/src/providers/aws/client.ts
+++ b/packages/sdk/src/providers/aws/client.ts
@@ -32,7 +32,6 @@ export type AwsClientCredentials = AwsCredentialIdentity | AwsCredentialIdentity
 
 export type AwsClientConfig = {
   region?: string;
-  credentials?: AwsClientCredentials;
 };
 
 const awsClientCredentialsContext = new AsyncLocalStorage<{ credentials?: AwsClientCredentials }>();
@@ -50,8 +49,8 @@ export const withAwsClientCredentials = <T>(
   fn: () => Promise<T>,
 ): Promise<T> => awsClientCredentialsContext.run({ credentials }, fn);
 
-const resolveAwsClientCredentials = (explicit?: AwsClientCredentials): AwsClientCredentials | undefined =>
-  explicit ?? awsClientCredentialsContext.getStore()?.credentials;
+const resolveAwsClientCredentials = (): AwsClientCredentials | undefined =>
+  awsClientCredentialsContext.getStore()?.credentials;
 
 const AWS_REGION_PATTERN = /^[a-z]{2}(?:-[a-z0-9]+)+-\d+$/;
 const AWS_GLOBAL_CONTROL_REGION = 'us-east-1';
@@ -136,175 +135,175 @@ export const assertSupportedAwsRegion = (region: string | undefined): AwsRegion 
 export const createEc2Client = (config: AwsClientConfig): EC2Client =>
   new EC2Client({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS ECS client for a specific region. */
 export const createEcsClient = (config: AwsClientConfig): ECSClient =>
   new ECSClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS EKS client for a specific region. */
 export const createEksClient = (config: AwsClientConfig): EKSClient =>
   new EKSClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS ECR client for a specific region. */
 export const createEcrClient = (config: AwsClientConfig): ECRClient =>
   new ECRClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Application Auto Scaling client for a specific region. */
 export const createApplicationAutoScalingClient = (config: AwsClientConfig): ApplicationAutoScalingClient =>
   new ApplicationAutoScalingClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS API Gateway REST API client for a specific region. */
 export const createApiGatewayClient = (config: AwsClientConfig): APIGatewayClient =>
   new APIGatewayClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Budgets client against the global billing control plane. */
-export const createBudgetsClient = (config: Pick<AwsClientConfig, 'credentials'> = {}): BudgetsClient =>
+export const createBudgetsClient = (): BudgetsClient =>
   new BudgetsClient({
     region: AWS_GLOBAL_CONTROL_REGION,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS ElastiCache client for a specific region. */
 export const createElastiCacheClient = (config: AwsClientConfig): ElastiCacheClient =>
   new ElastiCacheClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Classic ELB client for a specific region. */
 export const createElasticLoadBalancingClient = (config: AwsClientConfig): ElasticLoadBalancingClient =>
   new ElasticLoadBalancingClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS ELBv2 client for a specific region. */
 export const createElasticLoadBalancingV2Client = (config: AwsClientConfig): ElasticLoadBalancingV2Client =>
   new ElasticLoadBalancingV2Client({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS CloudWatch client for a specific region. */
 export const createCloudWatchClient = (config: AwsClientConfig): CloudWatchClient =>
   new CloudWatchClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS CloudTrail client for a specific region. */
 export const createCloudTrailClient = (config: AwsClientConfig): CloudTrailClient =>
   new CloudTrailClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS CloudFront client against the global control plane. */
-export const createCloudFrontClient = (config: Pick<AwsClientConfig, 'credentials'> = {}): CloudFrontClient =>
+export const createCloudFrontClient = (): CloudFrontClient =>
   new CloudFrontClient({
     region: AWS_GLOBAL_CONTROL_REGION,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS CloudWatch Logs client for a specific region. */
 export const createCloudWatchLogsClient = (config: AwsClientConfig): CloudWatchLogsClient =>
   new CloudWatchLogsClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Cost Explorer client against the global billing control plane. */
-export const createCostExplorerClient = (config: Pick<AwsClientConfig, 'credentials'> = {}): CostExplorerClient =>
+export const createCostExplorerClient = (): CostExplorerClient =>
   new CostExplorerClient({
     region: AWS_GLOBAL_CONTROL_REGION,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS DynamoDB client for a specific region. */
 export const createDynamoDbClient = (config: AwsClientConfig): DynamoDBClient =>
   new DynamoDBClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Lambda client for a specific region. */
 export const createLambdaClient = (config: AwsClientConfig): LambdaClient =>
   new LambdaClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS EMR client for a specific region. */
 export const createEmrClient = (config: AwsClientConfig): EMRClient =>
   new EMRClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS RDS client for a specific region. */
 export const createRdsClient = (config: AwsClientConfig): RDSClient =>
   new RDSClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Redshift client for a specific region. */
 export const createRedshiftClient = (config: AwsClientConfig): RedshiftClient =>
   new RedshiftClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Route 53 client against the global control plane. */
-export const createRoute53Client = (config: Pick<AwsClientConfig, 'credentials'> = {}): Route53Client =>
+export const createRoute53Client = (): Route53Client =>
   new Route53Client({
     region: AWS_GLOBAL_CONTROL_REGION,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS S3 client for a specific region. */
 export const createS3Client = (config: AwsClientConfig): S3Client =>
   new S3Client({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS SageMaker client for a specific region. */
 export const createSageMakerClient = (config: AwsClientConfig): SageMakerClient =>
   new SageMakerClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Secrets Manager client for a specific region. */
 export const createSecretsManagerClient = (config: AwsClientConfig): SecretsManagerClient =>
   new SecretsManagerClient({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /** Creates an AWS Resource Explorer client for a specific region. */
 export const createResourceExplorerClient = (config: AwsClientConfig): ResourceExplorer2Client =>
   new ResourceExplorer2Client({
     region: config.region,
-    credentials: resolveAwsClientCredentials(config.credentials),
+    credentials: resolveAwsClientCredentials(),
   });
 
 /**

--- a/packages/sdk/src/providers/aws/client.ts
+++ b/packages/sdk/src/providers/aws/client.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { APIGatewayClient } from '@aws-sdk/client-api-gateway';
 import { ApplicationAutoScalingClient } from '@aws-sdk/client-application-auto-scaling';
 import { BudgetsClient } from '@aws-sdk/client-budgets';
@@ -24,11 +25,33 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { SageMakerClient } from '@aws-sdk/client-sagemaker';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { AwsDiscoveryError } from './errors.js';
+
+export type AwsClientCredentials = AwsCredentialIdentity | AwsCredentialIdentityProvider;
 
 export type AwsClientConfig = {
   region?: string;
+  credentials?: AwsClientCredentials;
 };
+
+const awsClientCredentialsContext = new AsyncLocalStorage<{ credentials?: AwsClientCredentials }>();
+
+/**
+ * Runs a callback with ambient AWS credentials applied to every AWS client
+ * created inside it, without requiring each call site to thread credentials.
+ *
+ * @param credentials - Credentials or credential provider to scope to the callback.
+ * @param fn - Callback whose AWS client constructions should use the credentials.
+ * @returns The callback result.
+ */
+export const withAwsClientCredentials = <T>(
+  credentials: AwsClientCredentials | undefined,
+  fn: () => Promise<T>,
+): Promise<T> => awsClientCredentialsContext.run({ credentials }, fn);
+
+const resolveAwsClientCredentials = (explicit?: AwsClientCredentials): AwsClientCredentials | undefined =>
+  explicit ?? awsClientCredentialsContext.getStore()?.credentials;
 
 const AWS_REGION_PATTERN = /^[a-z]{2}(?:-[a-z0-9]+)+-\d+$/;
 const AWS_GLOBAL_CONTROL_REGION = 'us-east-1';
@@ -113,150 +136,175 @@ export const assertSupportedAwsRegion = (region: string | undefined): AwsRegion 
 export const createEc2Client = (config: AwsClientConfig): EC2Client =>
   new EC2Client({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS ECS client for a specific region. */
 export const createEcsClient = (config: AwsClientConfig): ECSClient =>
   new ECSClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS EKS client for a specific region. */
 export const createEksClient = (config: AwsClientConfig): EKSClient =>
   new EKSClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS ECR client for a specific region. */
 export const createEcrClient = (config: AwsClientConfig): ECRClient =>
   new ECRClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Application Auto Scaling client for a specific region. */
 export const createApplicationAutoScalingClient = (config: AwsClientConfig): ApplicationAutoScalingClient =>
   new ApplicationAutoScalingClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS API Gateway REST API client for a specific region. */
 export const createApiGatewayClient = (config: AwsClientConfig): APIGatewayClient =>
   new APIGatewayClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Budgets client against the global billing control plane. */
-export const createBudgetsClient = (): BudgetsClient =>
+export const createBudgetsClient = (config: Pick<AwsClientConfig, 'credentials'> = {}): BudgetsClient =>
   new BudgetsClient({
     region: AWS_GLOBAL_CONTROL_REGION,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS ElastiCache client for a specific region. */
 export const createElastiCacheClient = (config: AwsClientConfig): ElastiCacheClient =>
   new ElastiCacheClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Classic ELB client for a specific region. */
 export const createElasticLoadBalancingClient = (config: AwsClientConfig): ElasticLoadBalancingClient =>
   new ElasticLoadBalancingClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS ELBv2 client for a specific region. */
 export const createElasticLoadBalancingV2Client = (config: AwsClientConfig): ElasticLoadBalancingV2Client =>
   new ElasticLoadBalancingV2Client({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS CloudWatch client for a specific region. */
 export const createCloudWatchClient = (config: AwsClientConfig): CloudWatchClient =>
   new CloudWatchClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS CloudTrail client for a specific region. */
 export const createCloudTrailClient = (config: AwsClientConfig): CloudTrailClient =>
   new CloudTrailClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS CloudFront client against the global control plane. */
-export const createCloudFrontClient = (): CloudFrontClient =>
+export const createCloudFrontClient = (config: Pick<AwsClientConfig, 'credentials'> = {}): CloudFrontClient =>
   new CloudFrontClient({
     region: AWS_GLOBAL_CONTROL_REGION,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS CloudWatch Logs client for a specific region. */
 export const createCloudWatchLogsClient = (config: AwsClientConfig): CloudWatchLogsClient =>
   new CloudWatchLogsClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Cost Explorer client against the global billing control plane. */
-export const createCostExplorerClient = (): CostExplorerClient =>
+export const createCostExplorerClient = (config: Pick<AwsClientConfig, 'credentials'> = {}): CostExplorerClient =>
   new CostExplorerClient({
     region: AWS_GLOBAL_CONTROL_REGION,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS DynamoDB client for a specific region. */
 export const createDynamoDbClient = (config: AwsClientConfig): DynamoDBClient =>
   new DynamoDBClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Lambda client for a specific region. */
 export const createLambdaClient = (config: AwsClientConfig): LambdaClient =>
   new LambdaClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS EMR client for a specific region. */
 export const createEmrClient = (config: AwsClientConfig): EMRClient =>
   new EMRClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS RDS client for a specific region. */
 export const createRdsClient = (config: AwsClientConfig): RDSClient =>
   new RDSClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Redshift client for a specific region. */
 export const createRedshiftClient = (config: AwsClientConfig): RedshiftClient =>
   new RedshiftClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Route 53 client against the global control plane. */
-export const createRoute53Client = (): Route53Client =>
+export const createRoute53Client = (config: Pick<AwsClientConfig, 'credentials'> = {}): Route53Client =>
   new Route53Client({
     region: AWS_GLOBAL_CONTROL_REGION,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS S3 client for a specific region. */
 export const createS3Client = (config: AwsClientConfig): S3Client =>
   new S3Client({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS SageMaker client for a specific region. */
 export const createSageMakerClient = (config: AwsClientConfig): SageMakerClient =>
   new SageMakerClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Secrets Manager client for a specific region. */
 export const createSecretsManagerClient = (config: AwsClientConfig): SecretsManagerClient =>
   new SecretsManagerClient({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /** Creates an AWS Resource Explorer client for a specific region. */
 export const createResourceExplorerClient = (config: AwsClientConfig): ResourceExplorer2Client =>
   new ResourceExplorer2Client({
     region: config.region,
+    credentials: resolveAwsClientCredentials(config.credentials),
   });
 
 /**
@@ -282,7 +330,7 @@ export const resolveCurrentAwsRegion = async (): Promise<AwsRegion> => {
  * @returns The caller account ID.
  */
 export const resolveAwsAccountId = async (): Promise<string> => {
-  const client = new STSClient({});
+  const client = new STSClient({ credentials: resolveAwsClientCredentials() });
   const { Account } = await client.send(new GetCallerIdentityCommand({}));
 
   if (!Account) {

--- a/packages/sdk/src/scanner.ts
+++ b/packages/sdk/src/scanner.ts
@@ -3,6 +3,7 @@ import { mergeConfig } from './config/merge.js';
 import { emitDebugLog } from './debug.js';
 import { runLiveScan } from './engine/run-live.js';
 import { runStaticScan } from './engine/run-static.js';
+import { type AwsClientCredentials, withAwsClientCredentials } from './providers/aws/client.js';
 import {
   getAwsDiscoveryStatus,
   initializeAwsDiscovery,
@@ -66,20 +67,25 @@ export class CloudBurnClient {
   /**
    * Runs a live AWS discovery scan against a specific discovery target.
    *
-   * @param options - Optional discovery target and config overrides.
+   * @param options - Optional discovery target, config overrides, and AWS
+   *   credentials to use instead of the ambient credential provider chain.
    * @returns Grouped live scan findings.
    */
   public async discover(options?: {
     target?: AwsDiscoveryTarget;
     config?: Partial<CloudBurnConfig>;
     configPath?: string;
+    aws?: { credentials?: AwsClientCredentials };
   }): Promise<ScanResult> {
     emitDebugLog(this.options?.debugLogger, 'sdk: starting live discovery scan');
     const effectiveConfig = await this.getEffectiveConfig(options?.config, options?.configPath);
 
-    return runLiveScan(effectiveConfig, options?.target ?? { mode: 'current' }, {
-      debugLogger: this.options?.debugLogger,
-    });
+    const run = () =>
+      runLiveScan(effectiveConfig, options?.target ?? { mode: 'current' }, {
+        debugLogger: this.options?.debugLogger,
+      });
+
+    return options?.aws?.credentials ? withAwsClientCredentials(options.aws.credentials, run) : run();
   }
 
   /**

--- a/packages/sdk/test/exports.test.ts
+++ b/packages/sdk/test/exports.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { listBuiltInRuleMetadata } from '../src/built-in-rules.js';
 import {
   type AwsApiGatewayStage,
+  type AwsClientCredentials,
   type AwsCloudFrontDistribution,
   type AwsCloudTrailTrail,
   type AwsCloudWatchLogGroup,
@@ -27,6 +28,7 @@ import {
   builtInRuleMetadata,
   parseIaC,
   type Rule,
+  withAwsClientCredentials,
 } from '../src/index.js';
 
 const createRuleFixture = (id: string): Rule => ({
@@ -71,6 +73,16 @@ const sortRulesForMetadata = <TRule extends Pick<Rule, 'id' | 'provider' | 'serv
 describe('sdk exports', () => {
   it('exports the autodetect parser from the package root', () => {
     expect(parseIaC).toBeTypeOf('function');
+  });
+
+  it('exports the aws credential scoping helper from the package root', () => {
+    const staticCredentials: AwsClientCredentials = {
+      accessKeyId: 'AKIAEXPORT',
+      secretAccessKey: 'export-secret',
+    };
+
+    expect(withAwsClientCredentials).toBeTypeOf('function');
+    expect(staticCredentials.accessKeyId).toBe('AKIAEXPORT');
   });
 
   it('exports built-in rule metadata in stable provider/service/id order', () => {

--- a/packages/sdk/test/providers/aws-client-credentials.test.ts
+++ b/packages/sdk/test/providers/aws-client-credentials.test.ts
@@ -1,103 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import {
-  createApiGatewayClient,
-  createApplicationAutoScalingClient,
-  createBudgetsClient,
-  createCloudFrontClient,
-  createCloudTrailClient,
-  createCloudWatchClient,
-  createCloudWatchLogsClient,
-  createCostExplorerClient,
-  createDynamoDbClient,
-  createEc2Client,
-  createEcrClient,
-  createEcsClient,
-  createEksClient,
-  createElastiCacheClient,
-  createElasticLoadBalancingClient,
-  createElasticLoadBalancingV2Client,
-  createEmrClient,
-  createLambdaClient,
-  createRdsClient,
-  createRedshiftClient,
-  createResourceExplorerClient,
-  createRoute53Client,
-  createS3Client,
-  createSageMakerClient,
-  createSecretsManagerClient,
-  withAwsClientCredentials,
-} from '../../src/providers/aws/client.js';
+import { createCostExplorerClient, createEc2Client, withAwsClientCredentials } from '../../src/providers/aws/client.js';
 
-const explicitCredentials = {
-  accessKeyId: 'AKIAEXPLICIT',
-  secretAccessKey: 'explicit-secret',
-  sessionToken: 'explicit-session',
+const scanCredentials = {
+  accessKeyId: 'AKIASCOPED',
+  secretAccessKey: 'scoped-secret',
+  sessionToken: 'scoped-session',
 };
 
 type AnyAwsClient = { config: { credentials: () => Promise<Record<string, unknown>> } };
 
 const resolveClientCredentials = async (client: unknown) => (client as AnyAwsClient).config.credentials();
 
-const regionalFactories: Array<
-  [string, (config: { region?: string; credentials?: typeof explicitCredentials }) => unknown]
-> = [
-  ['createApiGatewayClient', createApiGatewayClient],
-  ['createApplicationAutoScalingClient', createApplicationAutoScalingClient],
-  ['createCloudTrailClient', createCloudTrailClient],
-  ['createCloudWatchClient', createCloudWatchClient],
-  ['createCloudWatchLogsClient', createCloudWatchLogsClient],
-  ['createDynamoDbClient', createDynamoDbClient],
-  ['createEc2Client', createEc2Client],
-  ['createEcrClient', createEcrClient],
-  ['createEcsClient', createEcsClient],
-  ['createEksClient', createEksClient],
-  ['createElastiCacheClient', createElastiCacheClient],
-  ['createElasticLoadBalancingClient', createElasticLoadBalancingClient],
-  ['createElasticLoadBalancingV2Client', createElasticLoadBalancingV2Client],
-  ['createEmrClient', createEmrClient],
-  ['createLambdaClient', createLambdaClient],
-  ['createRdsClient', createRdsClient],
-  ['createRedshiftClient', createRedshiftClient],
-  ['createResourceExplorerClient', createResourceExplorerClient],
-  ['createS3Client', createS3Client],
-  ['createSageMakerClient', createSageMakerClient],
-  ['createSecretsManagerClient', createSecretsManagerClient],
-];
-
-const globalFactories: Array<[string, (config?: { credentials?: typeof explicitCredentials }) => unknown]> = [
-  ['createBudgetsClient', createBudgetsClient],
-  ['createCloudFrontClient', createCloudFrontClient],
-  ['createCostExplorerClient', createCostExplorerClient],
-  ['createRoute53Client', createRoute53Client],
-];
-
 describe('withAwsClientCredentials', () => {
   it('applies scoped credentials to clients created inside the callback', async () => {
-    const client = await withAwsClientCredentials(explicitCredentials, async () =>
+    const client = await withAwsClientCredentials(scanCredentials, async () =>
       createEc2Client({ region: 'eu-central-1' }),
     );
 
-    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
+    await expect(resolveClientCredentials(client)).resolves.toMatchObject(scanCredentials);
   });
 
   it('applies scoped credentials to global-control-plane clients created inside the callback', async () => {
-    const client = await withAwsClientCredentials(explicitCredentials, async () => createCostExplorerClient());
+    const client = await withAwsClientCredentials(scanCredentials, async () => createCostExplorerClient());
 
-    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
-  });
-
-  it('prefers explicit factory credentials over scoped credentials', async () => {
-    const scopedCredentials = {
-      accessKeyId: 'AKIASCOPED',
-      secretAccessKey: 'scoped-secret',
-      sessionToken: 'scoped-session',
-    };
-
-    const client = await withAwsClientCredentials(scopedCredentials, async () =>
-      createEc2Client({ region: 'eu-central-1', credentials: explicitCredentials }),
-    );
-
-    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
+    await expect(resolveClientCredentials(client)).resolves.toMatchObject(scanCredentials);
   });
 
   it('isolates scoped credentials between concurrent callbacks', async () => {
@@ -118,19 +44,5 @@ describe('withAwsClientCredentials', () => {
 
     await expect(resolveClientCredentials(clientA)).resolves.toMatchObject(credentialsA);
     await expect(resolveClientCredentials(clientB)).resolves.toMatchObject(credentialsB);
-  });
-});
-
-describe('aws client factories with explicit credentials', () => {
-  it.each(regionalFactories)('%s passes explicit credentials into the client', async (_name, factory) => {
-    const client = factory({ region: 'eu-central-1', credentials: explicitCredentials });
-
-    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
-  });
-
-  it.each(globalFactories)('%s passes explicit credentials into the client', async (_name, factory) => {
-    const client = factory({ credentials: explicitCredentials });
-
-    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
   });
 });

--- a/packages/sdk/test/providers/aws-client-credentials.test.ts
+++ b/packages/sdk/test/providers/aws-client-credentials.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createApiGatewayClient,
+  createApplicationAutoScalingClient,
+  createBudgetsClient,
+  createCloudFrontClient,
+  createCloudTrailClient,
+  createCloudWatchClient,
+  createCloudWatchLogsClient,
+  createCostExplorerClient,
+  createDynamoDbClient,
+  createEc2Client,
+  createEcrClient,
+  createEcsClient,
+  createEksClient,
+  createElastiCacheClient,
+  createElasticLoadBalancingClient,
+  createElasticLoadBalancingV2Client,
+  createEmrClient,
+  createLambdaClient,
+  createRdsClient,
+  createRedshiftClient,
+  createResourceExplorerClient,
+  createRoute53Client,
+  createS3Client,
+  createSageMakerClient,
+  createSecretsManagerClient,
+  withAwsClientCredentials,
+} from '../../src/providers/aws/client.js';
+
+const explicitCredentials = {
+  accessKeyId: 'AKIAEXPLICIT',
+  secretAccessKey: 'explicit-secret',
+  sessionToken: 'explicit-session',
+};
+
+type AnyAwsClient = { config: { credentials: () => Promise<Record<string, unknown>> } };
+
+const resolveClientCredentials = async (client: unknown) => (client as AnyAwsClient).config.credentials();
+
+const regionalFactories: Array<
+  [string, (config: { region?: string; credentials?: typeof explicitCredentials }) => unknown]
+> = [
+  ['createApiGatewayClient', createApiGatewayClient],
+  ['createApplicationAutoScalingClient', createApplicationAutoScalingClient],
+  ['createCloudTrailClient', createCloudTrailClient],
+  ['createCloudWatchClient', createCloudWatchClient],
+  ['createCloudWatchLogsClient', createCloudWatchLogsClient],
+  ['createDynamoDbClient', createDynamoDbClient],
+  ['createEc2Client', createEc2Client],
+  ['createEcrClient', createEcrClient],
+  ['createEcsClient', createEcsClient],
+  ['createEksClient', createEksClient],
+  ['createElastiCacheClient', createElastiCacheClient],
+  ['createElasticLoadBalancingClient', createElasticLoadBalancingClient],
+  ['createElasticLoadBalancingV2Client', createElasticLoadBalancingV2Client],
+  ['createEmrClient', createEmrClient],
+  ['createLambdaClient', createLambdaClient],
+  ['createRdsClient', createRdsClient],
+  ['createRedshiftClient', createRedshiftClient],
+  ['createResourceExplorerClient', createResourceExplorerClient],
+  ['createS3Client', createS3Client],
+  ['createSageMakerClient', createSageMakerClient],
+  ['createSecretsManagerClient', createSecretsManagerClient],
+];
+
+const globalFactories: Array<[string, (config?: { credentials?: typeof explicitCredentials }) => unknown]> = [
+  ['createBudgetsClient', createBudgetsClient],
+  ['createCloudFrontClient', createCloudFrontClient],
+  ['createCostExplorerClient', createCostExplorerClient],
+  ['createRoute53Client', createRoute53Client],
+];
+
+describe('withAwsClientCredentials', () => {
+  it('applies scoped credentials to clients created inside the callback', async () => {
+    const client = await withAwsClientCredentials(explicitCredentials, async () =>
+      createEc2Client({ region: 'eu-central-1' }),
+    );
+
+    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
+  });
+
+  it('applies scoped credentials to global-control-plane clients created inside the callback', async () => {
+    const client = await withAwsClientCredentials(explicitCredentials, async () => createCostExplorerClient());
+
+    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
+  });
+
+  it('prefers explicit factory credentials over scoped credentials', async () => {
+    const scopedCredentials = {
+      accessKeyId: 'AKIASCOPED',
+      secretAccessKey: 'scoped-secret',
+      sessionToken: 'scoped-session',
+    };
+
+    const client = await withAwsClientCredentials(scopedCredentials, async () =>
+      createEc2Client({ region: 'eu-central-1', credentials: explicitCredentials }),
+    );
+
+    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
+  });
+
+  it('isolates scoped credentials between concurrent callbacks', async () => {
+    const credentialsA = { accessKeyId: 'AKIAAAA', secretAccessKey: 'secret-a', sessionToken: 'session-a' };
+    const credentialsB = { accessKeyId: 'AKIABBB', secretAccessKey: 'secret-b', sessionToken: 'session-b' };
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    const [clientA, clientB] = await Promise.all([
+      withAwsClientCredentials(credentialsA, async () => {
+        await settle();
+        return createEc2Client({ region: 'eu-central-1' });
+      }),
+      withAwsClientCredentials(credentialsB, async () => {
+        await settle();
+        return createEc2Client({ region: 'eu-central-1' });
+      }),
+    ]);
+
+    await expect(resolveClientCredentials(clientA)).resolves.toMatchObject(credentialsA);
+    await expect(resolveClientCredentials(clientB)).resolves.toMatchObject(credentialsB);
+  });
+});
+
+describe('aws client factories with explicit credentials', () => {
+  it.each(regionalFactories)('%s passes explicit credentials into the client', async (_name, factory) => {
+    const client = factory({ region: 'eu-central-1', credentials: explicitCredentials });
+
+    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
+  });
+
+  it.each(globalFactories)('%s passes explicit credentials into the client', async (_name, factory) => {
+    const client = factory({ credentials: explicitCredentials });
+
+    await expect(resolveClientCredentials(client)).resolves.toMatchObject(explicitCredentials);
+  });
+});

--- a/packages/sdk/test/scanner.test.ts
+++ b/packages/sdk/test/scanner.test.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import { LiveResourceBag } from '@cloudburn/rules';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createEc2Client } from '../src/providers/aws/client.js';
 import { discoverAwsResources } from '../src/providers/aws/discovery.js';
 import { CloudBurnClient } from '../src/scanner.js';
 
@@ -342,6 +343,34 @@ describe('CloudBurnClient', () => {
       ],
       providers: [],
     });
+  });
+
+  it('scopes aws credentials around live discovery so provider clients use them', async () => {
+    const scanCredentials = {
+      accessKeyId: 'AKIASCAN',
+      secretAccessKey: 'scan-secret',
+      sessionToken: 'scan-session',
+    };
+
+    mockedDiscoverAwsResources.mockImplementation(async () => {
+      const client = createEc2Client({ region: 'us-east-1' });
+      const resolved = await (client.config.credentials as () => Promise<Record<string, unknown>>)();
+      expect(resolved).toMatchObject(scanCredentials);
+
+      return {
+        catalog: discoveryCatalog,
+        resources: new LiveResourceBag(),
+      };
+    });
+
+    const scanner = new CloudBurnClient();
+
+    await scanner.discover({
+      target: { mode: 'regions', regions: ['us-east-1'] },
+      aws: { credentials: scanCredentials },
+    });
+
+    expect(mockedDiscoverAwsResources).toHaveBeenCalledOnce();
   });
 
   it('defaults discover to the current region target when none is provided', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       '@aws-sdk/client-sts':
         specifier: ^3.1003.0
         version: 3.1004.0
+      '@aws-sdk/types':
+        specifier: ^3.973.6
+        version: 3.973.6
       '@cdktf/hcl2json':
         specifier: ^0.21.0
         version: 0.21.0
@@ -709,10 +712,6 @@ packages:
 
   '@aws-sdk/token-providers@3.1019.0':
     resolution: {integrity: sha512-OF+2RfRmUKyjzrRWlDcyju3RBsuqcrYDQ8TwrJg8efcOotMzuZN4U9mpVTIdATpmEc4lWNZBMSjPzrGm6JPnAQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.5':
-    resolution: {integrity: sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -2616,20 +2615,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -2656,7 +2655,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -3080,7 +3079,7 @@ snapshots:
       '@aws-sdk/middleware-sdk-ec2': 3.972.13
       '@aws-sdk/middleware-user-agent': 3.972.18
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.3
@@ -3440,7 +3439,7 @@ snapshots:
       '@aws-sdk/middleware-recursion-detection': 3.972.7
       '@aws-sdk/middleware-user-agent': 3.972.19
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.4
@@ -3490,7 +3489,7 @@ snapshots:
       '@aws-sdk/middleware-sdk-rds': 3.972.14
       '@aws-sdk/middleware-user-agent': 3.972.20
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.5
@@ -3580,7 +3579,7 @@ snapshots:
       '@aws-sdk/middleware-recursion-detection': 3.972.7
       '@aws-sdk/middleware-user-agent': 3.972.19
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.4
@@ -3678,7 +3677,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.972.20
       '@aws-sdk/region-config-resolver': 3.972.7
       '@aws-sdk/signature-v4-multi-region': 3.996.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.5
@@ -3819,7 +3818,7 @@ snapshots:
       '@aws-sdk/middleware-recursion-detection': 3.972.7
       '@aws-sdk/middleware-user-agent': 3.972.19
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.4
@@ -3854,7 +3853,7 @@ snapshots:
 
   '@aws-sdk/core@3.973.18':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/xml-builder': 3.972.10
       '@smithy/core': 3.23.8
       '@smithy/node-config-provider': 4.3.11
@@ -3870,7 +3869,7 @@ snapshots:
 
   '@aws-sdk/core@3.973.19':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/xml-builder': 3.972.10
       '@smithy/core': 3.23.9
       '@smithy/node-config-provider': 4.3.11
@@ -3934,23 +3933,23 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.4':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.16':
     dependencies:
       '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.17':
     dependencies:
       '@aws-sdk/core': 3.973.19
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.18':
@@ -3980,26 +3979,26 @@ snapshots:
   '@aws-sdk/credential-provider-http@3.972.18':
     dependencies:
       '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/fetch-http-handler': 5.3.13
       '@smithy/node-http-handler': 4.4.14
       '@smithy/property-provider': 4.2.11
       '@smithy/protocol-http': 5.3.11
       '@smithy/smithy-client': 4.12.2
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.17
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.19':
     dependencies:
       '@aws-sdk/core': 3.973.19
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/fetch-http-handler': 5.3.13
       '@smithy/node-http-handler': 4.4.14
       '@smithy/property-provider': 4.2.11
       '@smithy/protocol-http': 5.3.11
       '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.17
       tslib: 2.8.1
 
@@ -4052,11 +4051,11 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.16
       '@aws-sdk/credential-provider-web-identity': 3.972.16
       '@aws-sdk/nested-clients': 3.996.6
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.11
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4071,11 +4070,11 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.17
       '@aws-sdk/credential-provider-web-identity': 3.972.17
       '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.11
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4090,11 +4089,11 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.18
       '@aws-sdk/credential-provider-web-identity': 3.972.18
       '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.11
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4160,11 +4159,11 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.18
       '@aws-sdk/nested-clients': 3.996.6
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/protocol-http': 5.3.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4173,11 +4172,11 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.18
       '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/protocol-http': 5.3.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4186,11 +4185,11 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/protocol-http': 5.3.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4242,7 +4241,7 @@ snapshots:
       '@aws-sdk/credential-provider-process': 3.972.16
       '@aws-sdk/credential-provider-sso': 3.972.16
       '@aws-sdk/credential-provider-web-identity': 3.972.16
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.11
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
@@ -4259,7 +4258,7 @@ snapshots:
       '@aws-sdk/credential-provider-process': 3.972.16
       '@aws-sdk/credential-provider-sso': 3.972.17
       '@aws-sdk/credential-provider-web-identity': 3.972.17
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.11
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
@@ -4276,7 +4275,7 @@ snapshots:
       '@aws-sdk/credential-provider-process': 3.972.17
       '@aws-sdk/credential-provider-sso': 3.972.18
       '@aws-sdk/credential-provider-web-identity': 3.972.18
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.11
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
@@ -4339,19 +4338,19 @@ snapshots:
   '@aws-sdk/credential-provider-process@3.972.16':
     dependencies:
       '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.17':
     dependencies:
       '@aws-sdk/core': 3.973.19
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.18':
@@ -4386,10 +4385,10 @@ snapshots:
       '@aws-sdk/core': 3.973.18
       '@aws-sdk/nested-clients': 3.996.6
       '@aws-sdk/token-providers': 3.1003.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4399,10 +4398,10 @@ snapshots:
       '@aws-sdk/core': 3.973.18
       '@aws-sdk/nested-clients': 3.996.7
       '@aws-sdk/token-providers': 3.1004.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4412,10 +4411,10 @@ snapshots:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.996.8
       '@aws-sdk/token-providers': 3.1005.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4463,10 +4462,10 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.18
       '@aws-sdk/nested-clients': 3.996.6
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4475,10 +4474,10 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.18
       '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4487,10 +4486,10 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4547,11 +4546,11 @@ snapshots:
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/node-config-provider': 4.3.11
       '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
@@ -4566,9 +4565,9 @@ snapshots:
 
   '@aws-sdk/middleware-expect-continue@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.973.5':
@@ -4578,11 +4577,11 @@ snapshots:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/crc64-nvme': 3.972.4
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/node-config-provider': 4.3.11
       '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-middleware': 4.2.11
       '@smithy/util-stream': 4.5.17
       '@smithy/util-utf8': 4.2.2
@@ -4590,7 +4589,7 @@ snapshots:
 
   '@aws-sdk/middleware-host-header@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/protocol-http': 5.3.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -4604,13 +4603,13 @@ snapshots:
 
   '@aws-sdk/middleware-location-constraint@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
@@ -4622,7 +4621,7 @@ snapshots:
 
   '@aws-sdk/middleware-recursion-detection@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws/lambda-invoke-store': 0.2.3
       '@smithy/protocol-http': 5.3.11
       '@smithy/types': 4.13.0
@@ -4653,7 +4652,7 @@ snapshots:
 
   '@aws-sdk/middleware-sdk-ec2@3.972.13':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-format-url': 3.972.7
       '@smithy/middleware-endpoint': 4.4.22
       '@smithy/protocol-http': 5.3.11
@@ -4664,7 +4663,7 @@ snapshots:
 
   '@aws-sdk/middleware-sdk-rds@3.972.14':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-format-url': 3.972.7
       '@smithy/middleware-endpoint': 4.4.23
       '@smithy/protocol-http': 5.3.11
@@ -4681,14 +4680,14 @@ snapshots:
   '@aws-sdk/middleware-sdk-s3@3.972.19':
     dependencies:
       '@aws-sdk/core': 3.973.19
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.23.9
       '@smithy/node-config-provider': 4.3.11
       '@smithy/protocol-http': 5.3.11
       '@smithy/signature-v4': 5.3.11
       '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-middleware': 4.2.11
       '@smithy/util-stream': 4.5.17
@@ -4697,14 +4696,14 @@ snapshots:
 
   '@aws-sdk/middleware-ssec@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.18':
     dependencies:
       '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@smithy/core': 3.23.8
       '@smithy/protocol-http': 5.3.11
@@ -4714,7 +4713,7 @@ snapshots:
   '@aws-sdk/middleware-user-agent@3.972.19':
     dependencies:
       '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@smithy/core': 3.23.8
       '@smithy/protocol-http': 5.3.11
@@ -4725,7 +4724,7 @@ snapshots:
   '@aws-sdk/middleware-user-agent@3.972.20':
     dependencies:
       '@aws-sdk/core': 3.973.19
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@smithy/core': 3.23.9
       '@smithy/protocol-http': 5.3.11
@@ -4905,7 +4904,7 @@ snapshots:
       '@aws-sdk/middleware-recursion-detection': 3.972.7
       '@aws-sdk/middleware-user-agent': 3.972.18
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.3
@@ -4923,7 +4922,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.14
       '@smithy/protocol-http': 5.3.11
       '@smithy/smithy-client': 4.12.2
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.11
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -4948,7 +4947,7 @@ snapshots:
       '@aws-sdk/middleware-recursion-detection': 3.972.7
       '@aws-sdk/middleware-user-agent': 3.972.19
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.4
@@ -4966,7 +4965,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.14
       '@smithy/protocol-http': 5.3.11
       '@smithy/smithy-client': 4.12.2
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.11
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -4991,7 +4990,7 @@ snapshots:
       '@aws-sdk/middleware-recursion-detection': 3.972.7
       '@aws-sdk/middleware-user-agent': 3.972.20
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
       '@aws-sdk/util-user-agent-node': 3.973.5
@@ -5009,7 +5008,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.14
       '@smithy/protocol-http': 5.3.11
       '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.11
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -5034,7 +5033,7 @@ snapshots:
 
   '@aws-sdk/region-config-resolver@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/config-resolver': 4.4.10
       '@smithy/node-config-provider': 4.3.11
       '@smithy/types': 4.13.0
@@ -5059,20 +5058,20 @@ snapshots:
   '@aws-sdk/signature-v4-multi-region@3.996.7':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.19
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/protocol-http': 5.3.11
       '@smithy/signature-v4': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1003.0':
     dependencies:
       '@aws-sdk/core': 3.973.18
       '@aws-sdk/nested-clients': 3.996.6
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5081,10 +5080,10 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.18
       '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5093,10 +5092,10 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5137,11 +5136,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.973.5':
-    dependencies:
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
   '@aws-sdk/types@3.973.6':
     dependencies:
       '@smithy/types': 4.13.1
@@ -5153,7 +5147,7 @@ snapshots:
 
   '@aws-sdk/util-endpoints@3.996.4':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/types': 4.13.0
       '@smithy/url-parser': 4.2.11
       '@smithy/util-endpoints': 3.3.2
@@ -5169,9 +5163,9 @@ snapshots:
 
   '@aws-sdk/util-format-url@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/querystring-builder': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -5180,7 +5174,7 @@ snapshots:
 
   '@aws-sdk/util-user-agent-browser@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/types': 4.13.0
       bowser: 2.14.1
       tslib: 2.8.1
@@ -5213,7 +5207,7 @@ snapshots:
   '@aws-sdk/util-user-agent-node@3.973.3':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.972.18
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -5221,7 +5215,7 @@ snapshots:
   '@aws-sdk/util-user-agent-node@3.973.4':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.972.19
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -5229,7 +5223,7 @@ snapshots:
   '@aws-sdk/util-user-agent-node@3.973.5':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.972.20
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -5245,7 +5239,7 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.10':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       fast-xml-parser: 5.4.1
       tslib: 2.8.1
 
@@ -5722,7 +5716,7 @@ snapshots:
 
   '@smithy/abort-controller@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/abort-controller@4.2.12':
@@ -5822,7 +5816,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.11
       '@smithy/property-provider': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.11
       tslib: 2.8.1
 
@@ -5837,7 +5831,7 @@ snapshots:
   '@smithy/eventstream-codec@4.2.11':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
@@ -5885,7 +5879,7 @@ snapshots:
   '@smithy/eventstream-serde-universal@4.2.11':
     dependencies:
       '@smithy/eventstream-codec': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-universal@4.2.12':
@@ -5914,7 +5908,7 @@ snapshots:
     dependencies:
       '@smithy/chunked-blob-reader': 5.2.2
       '@smithy/chunked-blob-reader-native': 4.2.3
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/hash-node@4.2.11':
@@ -5933,7 +5927,7 @@ snapshots:
 
   '@smithy/hash-stream-node@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -5957,7 +5951,7 @@ snapshots:
 
   '@smithy/md5-js@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -6148,7 +6142,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/property-provider@4.2.12':
@@ -6168,7 +6162,7 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
@@ -6180,7 +6174,7 @@ snapshots:
 
   '@smithy/querystring-parser@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.12':
@@ -6190,7 +6184,7 @@ snapshots:
 
   '@smithy/service-error-classification@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
 
   '@smithy/service-error-classification@4.2.12':
     dependencies:
@@ -6198,7 +6192,7 @@ snapshots:
 
   '@smithy/shared-ini-file-loader@4.4.6':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.7':
@@ -6210,7 +6204,7 @@ snapshots:
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-middleware': 4.2.11
       '@smithy/util-uri-escape': 4.2.2


### PR DESCRIPTION
## Summary

Adds a credentials passthrough to `@cloudburn/sdk` so integrators can run live discovery with STS-assumed credentials instead of the ambient AWS credential provider chain. This unblocks the CloudBurn app's upcoming unused-resources scanner, which assumes each customer's `CloudBurnReadOnlyRole` and must scan *their* account, not the Lambda's own.

- `src/providers/aws/client.ts`: new `AwsClientCredentials` type and an `AsyncLocalStorage`-backed credentials context with `withAwsClientCredentials()`; every `createXClient` factory resolves credentials from that context (falling back to the standard provider chain when unscoped). `resolveAwsAccountId`'s bare `STSClient` participates too.
- `src/scanner.ts`: `discover({ aws: { credentials } })` scopes the whole live scan to the given credentials.
- Public exports: `withAwsClientCredentials`, `AwsClientCredentials`.
- Fully backward compatible: with no scope active, every client resolves `credentials: undefined` and uses the standard provider chain; CLI behavior is unchanged.
- Applied simplify review: no per-factory explicit credentials override (no caller; factories are not exported) — the ALS scope is the single mechanism.

Tests: scoped application to regional + global-control-plane clients, concurrent-scope isolation, `discover()` scoping, export surface. Full suite: 310 tests green, typecheck clean. (Whole-package `biome check` intermittently dies with the known local OOM warning; all changed files lint clean individually.)

## Diagram

```mermaid
flowchart LR
  App["Integrator (scan Lambda)"] -->|"discover({ aws: { credentials } })"| SDK[CloudBurnClient]
  SDK -->|withAwsClientCredentials| ALS[AsyncLocalStorage context]
  ALS -->|resolveAwsClientCredentials| F[createXClient factories]
  F -->|scoped ?? ambient chain| AWS[AWS SDK v3 clients]
```
