### PR TITLE
fix(sdk): harden live discovery and static scan resilience

### DIFF
--- a/.changeset/quiet-donkeys-shiver.md
+++ b/.changeset/quiet-donkeys-shiver.md
@@ -1,0 +1,5 @@
+---
+'@cloudburn/sdk': patch
+---
+
+Harden live discovery and static scanning: CloudWatch Logs metric-filter hydration now bounds concurrent DescribeMetricFilters calls, every AWS client uses adaptive retry mode with explicit connection/request timeouts, and malformed Terraform files are skipped instead of aborting the entire static scan.

--- a/packages/sdk/src/parsers/terraform.ts
+++ b/packages/sdk/src/parsers/terraform.ts
@@ -150,8 +150,6 @@ const toIaCResources = async (path: string, scanRoot: string): Promise<IaCResour
   }
 
   const contents = await readFile(path, 'utf8');
-  const relativePath = toRelativePath(path, scanRoot);
-  const locations = locateResourceBlocks(contents, relativePath);
 
   // Parse failures are treated as "not a valid Terraform file" rather than
   // aborting the scan, matching the CloudFormation parser's behavior for
@@ -169,6 +167,9 @@ const toIaCResources = async (path: string, scanRoot: string): Promise<IaCResour
   if (!parsedResources || typeof parsedResources !== 'object') {
     return [];
   }
+
+  const relativePath = toRelativePath(path, scanRoot);
+  const locations = locateResourceBlocks(contents, relativePath);
 
   const resources = Object.entries(parsedResources).flatMap(([resourceType, namedResources]) => {
     if (!resourceType.startsWith('aws_') || typeof namedResources !== 'object' || namedResources === null) {

--- a/packages/sdk/src/parsers/terraform.ts
+++ b/packages/sdk/src/parsers/terraform.ts
@@ -152,7 +152,18 @@ const toIaCResources = async (path: string, scanRoot: string): Promise<IaCResour
   const contents = await readFile(path, 'utf8');
   const relativePath = toRelativePath(path, scanRoot);
   const locations = locateResourceBlocks(contents, relativePath);
-  const parsed = await parseHcl(path, contents);
+
+  // Parse failures are treated as "not a valid Terraform file" rather than
+  // aborting the scan, matching the CloudFormation parser's behavior for
+  // malformed templates.
+  let parsed: Awaited<ReturnType<typeof parseHcl>>;
+
+  try {
+    parsed = await parseHcl(path, contents);
+  } catch {
+    return [];
+  }
+
   const parsedResources = parsed.resource;
 
   if (!parsedResources || typeof parsedResources !== 'object') {

--- a/packages/sdk/src/providers/aws/client.ts
+++ b/packages/sdk/src/providers/aws/client.ts
@@ -32,6 +32,22 @@ export type AwsClientConfig = {
 
 const AWS_REGION_PATTERN = /^[a-z]{2}(?:-[a-z0-9]+)+-\d+$/;
 const AWS_GLOBAL_CONTROL_REGION = 'us-east-1';
+const AWS_CLIENT_MAX_ATTEMPTS = 3;
+const AWS_CLIENT_CONNECTION_TIMEOUT_MS = 5_000;
+const AWS_CLIENT_REQUEST_TIMEOUT_MS = 30_000;
+
+// Adaptive retry mode rate-limits the client proactively when AWS throttles;
+// retries beyond these attempts are owned by withAwsServiceErrorContext. Node
+// sockets have no default timeout, so without explicit request timeouts a hung
+// connection would stall a discovery run indefinitely.
+const baseAwsClientConfig = () => ({
+  maxAttempts: AWS_CLIENT_MAX_ATTEMPTS,
+  requestHandler: {
+    connectionTimeout: AWS_CLIENT_CONNECTION_TIMEOUT_MS,
+    requestTimeout: AWS_CLIENT_REQUEST_TIMEOUT_MS,
+  },
+  retryMode: 'adaptive',
+});
 export const AWS_REGIONS = [
   'af-south-1',
   'ap-east-1',
@@ -112,150 +128,175 @@ export const assertSupportedAwsRegion = (region: string | undefined): AwsRegion 
 /** Creates an AWS EC2 client for a specific region. */
 export const createEc2Client = (config: AwsClientConfig): EC2Client =>
   new EC2Client({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS ECS client for a specific region. */
 export const createEcsClient = (config: AwsClientConfig): ECSClient =>
   new ECSClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS EKS client for a specific region. */
 export const createEksClient = (config: AwsClientConfig): EKSClient =>
   new EKSClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS ECR client for a specific region. */
 export const createEcrClient = (config: AwsClientConfig): ECRClient =>
   new ECRClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Application Auto Scaling client for a specific region. */
 export const createApplicationAutoScalingClient = (config: AwsClientConfig): ApplicationAutoScalingClient =>
   new ApplicationAutoScalingClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS API Gateway REST API client for a specific region. */
 export const createApiGatewayClient = (config: AwsClientConfig): APIGatewayClient =>
   new APIGatewayClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Budgets client against the global billing control plane. */
 export const createBudgetsClient = (): BudgetsClient =>
   new BudgetsClient({
+    ...baseAwsClientConfig(),
     region: AWS_GLOBAL_CONTROL_REGION,
   });
 
 /** Creates an AWS ElastiCache client for a specific region. */
 export const createElastiCacheClient = (config: AwsClientConfig): ElastiCacheClient =>
   new ElastiCacheClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Classic ELB client for a specific region. */
 export const createElasticLoadBalancingClient = (config: AwsClientConfig): ElasticLoadBalancingClient =>
   new ElasticLoadBalancingClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS ELBv2 client for a specific region. */
 export const createElasticLoadBalancingV2Client = (config: AwsClientConfig): ElasticLoadBalancingV2Client =>
   new ElasticLoadBalancingV2Client({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS CloudWatch client for a specific region. */
 export const createCloudWatchClient = (config: AwsClientConfig): CloudWatchClient =>
   new CloudWatchClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS CloudTrail client for a specific region. */
 export const createCloudTrailClient = (config: AwsClientConfig): CloudTrailClient =>
   new CloudTrailClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS CloudFront client against the global control plane. */
 export const createCloudFrontClient = (): CloudFrontClient =>
   new CloudFrontClient({
+    ...baseAwsClientConfig(),
     region: AWS_GLOBAL_CONTROL_REGION,
   });
 
 /** Creates an AWS CloudWatch Logs client for a specific region. */
 export const createCloudWatchLogsClient = (config: AwsClientConfig): CloudWatchLogsClient =>
   new CloudWatchLogsClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Cost Explorer client against the global billing control plane. */
 export const createCostExplorerClient = (): CostExplorerClient =>
   new CostExplorerClient({
+    ...baseAwsClientConfig(),
     region: AWS_GLOBAL_CONTROL_REGION,
   });
 
 /** Creates an AWS DynamoDB client for a specific region. */
 export const createDynamoDbClient = (config: AwsClientConfig): DynamoDBClient =>
   new DynamoDBClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Lambda client for a specific region. */
 export const createLambdaClient = (config: AwsClientConfig): LambdaClient =>
   new LambdaClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS EMR client for a specific region. */
 export const createEmrClient = (config: AwsClientConfig): EMRClient =>
   new EMRClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS RDS client for a specific region. */
 export const createRdsClient = (config: AwsClientConfig): RDSClient =>
   new RDSClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Redshift client for a specific region. */
 export const createRedshiftClient = (config: AwsClientConfig): RedshiftClient =>
   new RedshiftClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Route 53 client against the global control plane. */
 export const createRoute53Client = (): Route53Client =>
   new Route53Client({
+    ...baseAwsClientConfig(),
     region: AWS_GLOBAL_CONTROL_REGION,
   });
 
 /** Creates an AWS S3 client for a specific region. */
 export const createS3Client = (config: AwsClientConfig): S3Client =>
   new S3Client({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS SageMaker client for a specific region. */
 export const createSageMakerClient = (config: AwsClientConfig): SageMakerClient =>
   new SageMakerClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Secrets Manager client for a specific region. */
 export const createSecretsManagerClient = (config: AwsClientConfig): SecretsManagerClient =>
   new SecretsManagerClient({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
 /** Creates an AWS Resource Explorer client for a specific region. */
 export const createResourceExplorerClient = (config: AwsClientConfig): ResourceExplorer2Client =>
   new ResourceExplorer2Client({
+    ...baseAwsClientConfig(),
     region: config.region,
   });
 
@@ -282,7 +323,7 @@ export const resolveCurrentAwsRegion = async (): Promise<AwsRegion> => {
  * @returns The caller account ID.
  */
 export const resolveAwsAccountId = async (): Promise<string> => {
-  const client = new STSClient({});
+  const client = new STSClient(baseAwsClientConfig());
   const { Account } = await client.send(new GetCallerIdentityCommand({}));
 
   if (!Account) {

--- a/packages/sdk/src/providers/aws/resources/cloudwatch-logs.ts
+++ b/packages/sdk/src/providers/aws/resources/cloudwatch-logs.ts
@@ -15,6 +15,7 @@ import { chunkItems, withAwsServiceErrorContext } from './utils.js';
 
 const CLOUDWATCH_LOG_GROUP_ARN_PATTERN = /^arn:[^:]+:logs:[^:]+:[^:]+:log-group:(.+)$/u;
 const CLOUDWATCH_LOG_STREAM_ACTIVITY_CONCURRENCY = 10;
+const CLOUDWATCH_METRIC_FILTER_CONCURRENCY = 10;
 
 const extractAccountIdFromArn = (arn: string): string | null => {
   const arnSegments = arn.split(':');
@@ -308,37 +309,43 @@ export const hydrateAwsCloudWatchLogMetricFilterCoverage = async (
         }),
       );
 
-      const coverage = await Promise.all(
-        [...desiredLogGroups.entries()].map(async ([logGroupName, accountId]) => {
-          let nextToken: string | undefined;
-          let metricFilterCount = 0;
+      const coverage: AwsCloudWatchLogMetricFilterCoverage[] = [];
 
-          do {
-            const response = await withAwsServiceErrorContext(
-              'Amazon CloudWatch Logs',
-              'DescribeMetricFilters',
+      for (const batch of chunkItems([...desiredLogGroups.entries()], CLOUDWATCH_METRIC_FILTER_CONCURRENCY)) {
+        const hydratedBatch = await Promise.all(
+          batch.map(async ([logGroupName, accountId]) => {
+            let nextToken: string | undefined;
+            let metricFilterCount = 0;
+
+            do {
+              const response = await withAwsServiceErrorContext(
+                'Amazon CloudWatch Logs',
+                'DescribeMetricFilters',
+                region,
+                () =>
+                  client.send(
+                    new DescribeMetricFiltersCommand({
+                      logGroupName,
+                      nextToken,
+                    }),
+                  ),
+              );
+
+              metricFilterCount += (response.metricFilters ?? []).length;
+              nextToken = response.nextToken;
+            } while (nextToken);
+
+            return {
+              accountId,
+              logGroupName,
+              metricFilterCount,
               region,
-              () =>
-                client.send(
-                  new DescribeMetricFiltersCommand({
-                    logGroupName,
-                    nextToken,
-                  }),
-                ),
-            );
+            } satisfies AwsCloudWatchLogMetricFilterCoverage;
+          }),
+        );
 
-            metricFilterCount += (response.metricFilters ?? []).length;
-            nextToken = response.nextToken;
-          } while (nextToken);
-
-          return {
-            accountId,
-            logGroupName,
-            metricFilterCount,
-            region,
-          } satisfies AwsCloudWatchLogMetricFilterCoverage;
-        }),
-      );
+        coverage.push(...hydratedBatch);
+      }
 
       return coverage;
     }),

--- a/packages/sdk/src/providers/aws/resources/cloudwatch-logs.ts
+++ b/packages/sdk/src/providers/aws/resources/cloudwatch-logs.ts
@@ -14,8 +14,7 @@ import { createCloudWatchLogsClient } from '../client.js';
 import { chunkItems, withAwsServiceErrorContext } from './utils.js';
 
 const CLOUDWATCH_LOG_GROUP_ARN_PATTERN = /^arn:[^:]+:logs:[^:]+:[^:]+:log-group:(.+)$/u;
-const CLOUDWATCH_LOG_STREAM_ACTIVITY_CONCURRENCY = 10;
-const CLOUDWATCH_METRIC_FILTER_CONCURRENCY = 10;
+const CLOUDWATCH_LOG_GROUP_HYDRATION_CONCURRENCY = 10;
 
 const extractAccountIdFromArn = (arn: string): string | null => {
   const arnSegments = arn.split(':');
@@ -234,7 +233,7 @@ export const hydrateAwsCloudWatchLogGroupRecentStreamActivity = async (
       );
       const activity: AwsCloudWatchLogGroupRecentStreamActivity[] = [];
 
-      for (const batch of chunkItems([...desiredLogGroups.entries()], CLOUDWATCH_LOG_STREAM_ACTIVITY_CONCURRENCY)) {
+      for (const batch of chunkItems([...desiredLogGroups.entries()], CLOUDWATCH_LOG_GROUP_HYDRATION_CONCURRENCY)) {
         const hydratedBatch = await Promise.all(
           batch.map(async ([logGroupName, discoveredAccountId]) => {
             const response = await withAwsServiceErrorContext(
@@ -311,7 +310,7 @@ export const hydrateAwsCloudWatchLogMetricFilterCoverage = async (
 
       const coverage: AwsCloudWatchLogMetricFilterCoverage[] = [];
 
-      for (const batch of chunkItems([...desiredLogGroups.entries()], CLOUDWATCH_METRIC_FILTER_CONCURRENCY)) {
+      for (const batch of chunkItems([...desiredLogGroups.entries()], CLOUDWATCH_LOG_GROUP_HYDRATION_CONCURRENCY)) {
         const hydratedBatch = await Promise.all(
           batch.map(async ([logGroupName, accountId]) => {
             let nextToken: string | undefined;

--- a/packages/sdk/test/fixtures/terraform/invalid-syntax/broken.tf
+++ b/packages/sdk/test/fixtures/terraform/invalid-syntax/broken.tf
@@ -1,0 +1,3 @@
+resource "aws_ebs_volume" "broken" {
+  availability_zone = "eu-west-1a"
+  size              =

--- a/packages/sdk/test/fixtures/terraform/invalid-syntax/valid.tf
+++ b/packages/sdk/test/fixtures/terraform/invalid-syntax/valid.tf
@@ -1,0 +1,5 @@
+resource "aws_ebs_volume" "gp2_sibling" {
+  availability_zone = "eu-west-1a"
+  size              = 25
+  type              = "gp2"
+}

--- a/packages/sdk/test/parsers.test.ts
+++ b/packages/sdk/test/parsers.test.ts
@@ -333,6 +333,53 @@ describe('parsers', () => {
     expect(resources).toEqual([]);
   });
 
+  it('returns no terraform resources for files with invalid hcl syntax', async () => {
+    const resourcePath = fileURLToPath(new URL('./fixtures/terraform/invalid-syntax/broken.tf', import.meta.url));
+    const resources = await parseTerraform(resourcePath);
+
+    expect(resources).toEqual([]);
+  });
+
+  it('keeps valid terraform resources when a sibling terraform file has invalid syntax', async () => {
+    const resourcePath = fileURLToPath(new URL('./fixtures/terraform/invalid-syntax', import.meta.url));
+    const resources = await parseTerraform(resourcePath);
+
+    expect(resources).toEqual([
+      {
+        provider: 'aws',
+        type: 'aws_ebs_volume',
+        name: 'gp2_sibling',
+        location: {
+          path: 'valid.tf',
+          line: 1,
+          column: 1,
+        },
+        attributeLocations: {
+          availability_zone: {
+            path: 'valid.tf',
+            line: 2,
+            column: 3,
+          },
+          size: {
+            path: 'valid.tf',
+            line: 3,
+            column: 3,
+          },
+          type: {
+            path: 'valid.tf',
+            line: 4,
+            column: 3,
+          },
+        },
+        attributes: {
+          availability_zone: 'eu-west-1a',
+          size: 25,
+          type: 'gp2',
+        },
+      },
+    ]);
+  });
+
   it('returns no terraform resources when files contain only non-aws resources', async () => {
     const resourcePath = fileURLToPath(new URL('./fixtures/terraform/no-resources', import.meta.url));
     const resources = await parseTerraform(resourcePath);

--- a/packages/sdk/test/providers/aws-client.test.ts
+++ b/packages/sdk/test/providers/aws-client.test.ts
@@ -2,6 +2,36 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const importClientModule = async () => import('../../src/providers/aws/client.js');
 
+describe('aws client resilience defaults', () => {
+  it('configures adaptive retries, explicit max attempts, and request timeouts on every client factory', async () => {
+    const clientModule = await importClientModule();
+    const factories = Object.entries(clientModule).filter(
+      (entry): entry is [string, (config: { region?: string }) => unknown] =>
+        entry[0].startsWith('create') && typeof entry[1] === 'function',
+    );
+
+    expect(factories.length).toBeGreaterThan(0);
+
+    for (const [factoryName, factory] of factories) {
+      const client = factory({ region: 'us-east-1' }) as {
+        config: {
+          maxAttempts: () => Promise<number>;
+          requestHandler: { configProvider: Promise<{ connectionTimeout?: number; requestTimeout?: number }> };
+          retryMode: string;
+        };
+      };
+
+      expect(client.config.retryMode, `${factoryName} retryMode`).toBe('adaptive');
+      await expect(client.config.maxAttempts(), `${factoryName} maxAttempts`).resolves.toBe(3);
+
+      const handlerConfig = await client.config.requestHandler.configProvider;
+
+      expect(handlerConfig.connectionTimeout, `${factoryName} connectionTimeout`).toBe(5_000);
+      expect(handlerConfig.requestTimeout, `${factoryName} requestTimeout`).toBe(30_000);
+    }
+  });
+});
+
 describe('resolveCurrentAwsRegion', { timeout: 30_000 }, () => {
   afterEach(() => {
     vi.resetModules();

--- a/packages/sdk/test/providers/aws-client.test.ts
+++ b/packages/sdk/test/providers/aws-client.test.ts
@@ -20,14 +20,21 @@ describe('aws client resilience defaults', () => {
           retryMode: string;
         };
       };
-
-      expect(client.config.retryMode, `${factoryName} retryMode`).toBe('adaptive');
-      await expect(client.config.maxAttempts(), `${factoryName} maxAttempts`).resolves.toBe(3);
-
       const handlerConfig = await client.config.requestHandler.configProvider;
 
-      expect(handlerConfig.connectionTimeout, `${factoryName} connectionTimeout`).toBe(5_000);
-      expect(handlerConfig.requestTimeout, `${factoryName} requestTimeout`).toBe(30_000);
+      expect({
+        factoryName,
+        retryMode: client.config.retryMode,
+        maxAttempts: await client.config.maxAttempts(),
+        connectionTimeout: handlerConfig.connectionTimeout,
+        requestTimeout: handlerConfig.requestTimeout,
+      }).toEqual({
+        factoryName,
+        retryMode: 'adaptive',
+        maxAttempts: 3,
+        connectionTimeout: 5_000,
+        requestTimeout: 30_000,
+      });
     }
   });
 });

--- a/packages/sdk/test/providers/aws-cloudwatch-logs-resource.test.ts
+++ b/packages/sdk/test/providers/aws-cloudwatch-logs-resource.test.ts
@@ -476,6 +476,38 @@ describe('hydrateAwsCloudWatchLogMetricFilterCoverage', () => {
     ]);
   });
 
+  it('bounds concurrent DescribeMetricFilters calls within a region', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const send = vi.fn(async (_command: DescribeMetricFiltersCommand) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+      inFlight -= 1;
+
+      return { metricFilters: [{ filterName: 'errors' }] };
+    });
+
+    mockedCreateCloudWatchLogsClient.mockReturnValue({ send } as never);
+
+    const coverage = await hydrateAwsCloudWatchLogMetricFilterCoverage(
+      Array.from({ length: 25 }, (_, index) => ({
+        accountId: '123456789012',
+        arn: `arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/app-${index}`,
+        properties: [],
+        region: 'us-east-1',
+        resourceType: 'logs:log-group',
+        service: 'logs',
+      })),
+    );
+
+    expect(coverage).toHaveLength(25);
+    expect(send).toHaveBeenCalledTimes(25);
+    expect(maxInFlight).toBeLessThanOrEqual(10);
+  });
+
   it('preserves CloudWatch Logs error identity when metric-filter hydration is access denied', async () => {
     mockedCreateCloudWatchLogsClient.mockReturnValue({
       send: vi.fn().mockRejectedValue(


### PR DESCRIPTION
## Summary

- What changed?
  - **Bounded CloudWatch Logs fan-out:** `hydrateAwsCloudWatchLogMetricFilterCoverage` issued one `DescribeMetricFilters` call per discovered log group in a single unbounded `Promise.all`. It now batches via `chunkItems` with a shared per-file concurrency of 10, matching the sibling stream-activity hydrator.
  - **Client resilience defaults:** every AWS client factory (plus the STS client) now applies a shared base config: `retryMode: 'adaptive'`, explicit `maxAttempts: 3`, and request handler timeouts (5s connection / 30s request). Adaptive mode makes the SDK proactively rate-limit itself when AWS throttles; the timeouts prevent a hung socket from stalling a discovery run indefinitely (Node sockets have no default timeout). A generic test asserts these defaults on every `create*` factory export so future factories cannot silently miss them.
  - **Malformed Terraform no longer aborts the scan:** `parseHcl` failures were uncaught, so a single `.tf` file with a syntax error crashed the entire static scan. Parse failures are now treated as "not a valid Terraform file" and skipped, matching the CloudFormation parser's existing behavior for malformed templates.
- Why was this needed? In large accounts the unbounded metric-filter fan-out could fire thousands of concurrent API calls per region (throttling risk), clients had no proactive rate-limiting or timeouts, and one in-progress Terraform edit could take down a whole `scan` run.

## Diagram

```mermaid
flowchart TB
    subgraph Discovery["Live discovery hardening"]
        A[Discovered log groups] -->|before: unbounded Promise.all| B[DescribeMetricFilters]
        A -->|after: chunkItems, max 10 in flight| B
        C[baseAwsClientConfig] -->|adaptive retryMode / maxAttempts 3 / 5s connect + 30s request timeouts| D[All AWS client factories + STS]
    end
    subgraph Static["Static scan hardening"]
        E[.tf file] --> F{parseHcl}
        F -->|valid| G[IaCResource entries]
        F -->|throws - before: aborts entire scan| H[crash]
        F -->|throws - after: skip file, keep scanning| I[empty result for file]
    end
    style H stroke:#f66,stroke-dasharray: 5 5
```

## Scope

- [ ] `cloudburn` (cli)
- [x] `@cloudburn/sdk`
- [ ] `@cloudburn/rules`
- [ ] docs/community files

## Release Notes

- [x] Added a `.changeset/*.md` file for published package changes
- [ ] No published package changes in this PR

## Verification

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm verify`

## Boundary Checks

- [x] No engine/parser/provider logic added to `@cloudburn/rules`
- [x] CLI delegates scan logic to SDK
- [x] README/CONTRIBUTING/docs updated when behavior changed (no user-facing behavior contract changed; failure handling only)

## Related Issues

None found (`gh issue list` shows only #64, unrelated).