### PR TITLE
feat(sdk): reuse metric intervals and coalesce CloudWatch queries

### DIFF
--- a/.changeset/silver-metrics-reuse.md
+++ b/.changeset/silver-metrics-reuse.md
@@ -1,0 +1,5 @@
+---
+'@cloudburn/sdk': minor
+---
+
+Reuse complete historical CloudWatch metric intervals across scans and combine compatible pending queries across datasets. Refresh recent intervals for late data while preserving exact observation windows, sample-weighted aggregates, per-series status, and independent cancellation.

--- a/docs/architecture/sdk.md
+++ b/docs/architecture/sdk.md
@@ -189,6 +189,12 @@ inventories; absent Classic listener metadata cannot establish HTTP-only support
 
 ### CloudWatch metric evidence
 
+With evidence caching configured, metric collectors reuse complete historical intervals through the existing scoped
+cache. A bounded planner coalesces compatible pending queries across datasets and gives shared requests independent
+cancellation ownership. Requested windows, per-series status, and raw Sum/SampleCount inputs remain intact. See
+[incremental metrics](../reference/evidence-cache.md#incremental-cloudwatch-metrics) for revalidation, storage sizing,
+planning limits, telemetry, and measured synthetic request savings.
+
 The [metric helper](../../packages/sdk/src/providers/aws/resources/cloudwatch.ts) returns one `CloudWatchMetricEvidence`
 record for every requested query ID. Each record retains the final AWS status, requested start/end and aggregation
 period, normalized points, expected and observed interval counts, request/query messages, and query attempt count.

--- a/docs/reference/evidence-cache.md
+++ b/docs/reference/evidence-cache.md
@@ -119,6 +119,60 @@ Supporting provenance survives reuse of its parent dataset. For example, unknown
 complete activity evidence is cached. CLI JSON preserves the array; table output summarizes sources, incompleteness, and
 the oldest observation. Existing `evaluations` retain rule-specific assessed/unknown coverage on every scan.
 
+## Incremental CloudWatch metrics
+
+The [metric cache](../../packages/sdk/src/providers/aws/metric-cache.ts) consumes the same scoped `load` contract as
+catalog and dataset evidence. It stores complete raw metric points in daily intervals, retaining exact partial edges
+and aggregation phase. Keys include namespace, metric name, sorted dimensions, statistic, period, Region, and interval,
+plus the existing partition/account/authorization/target scope. Caller query IDs do not affect reuse. A different
+statistic or authorization context cannot reuse an incompatible interval.
+
+When a derived dataset expires or its observation window moves, fresh complete intervals can still be reused. Intervals
+ending within the previous 3 days have a 5-minute TTL; older intervals have a 7-day TTL. These are initial policies,
+not an AWS guarantee that history becomes immutable. Expired recent intervals are recollected and replaced, including
+late or revised points. Older history is periodically revalidated too. Missing, partial, forbidden, malformed, and
+failed series cannot publish complete intervals. A complete empty series retains the existing sparse-metric semantics;
+missing datapoints never become zero values.
+
+`ttlMs.datasets['metric-buckets']` overrides both interval TTLs. Set it to zero to recollect all requested metric
+intervals. A zero TTL on an individual derived dataset only expires that dataset; its reusable supporting evidence
+retains its own policy. `refresh` recollects all requested intervals, and `off` bypasses metric persistence. Existing
+invalidation, leases, and independent waiter cancellation apply without a separate cache interface.
+
+The [planner](../../packages/sdk/src/providers/aws/metric-planner.ts) merges adjacent missing/revalidation intervals of
+the same metric and combines metrics with identical resulting windows across pending dataset requests in one scan.
+It does not expand windows or query unselected metrics. Partial-period aggregates only combine when their exact windows match. The collection delay is at most 5 ms before queueing for
+admission. At most 8192 query references are admitted and 2 combined collectors run concurrently; excess callers wait
+for capacity with cancellation. The existing collector still enforces 500 queries and 100,800 datapoints per request
+page, pagination, retries, and shared request/datapoint quotas. A combined request owns its execution independently of
+its first waiter. Cancelling all consumers removes queued work and aborts transport; cancelling one consumer preserves
+work still needed by another, including a cache waiter in another scan.
+
+Daily intervals align to the requested aggregation phase. A moving rolling-window edge may require a separate narrow
+request, and changing the phase (for example, moving an hourly Lambda window from 12:00 to 12:05) prevents historical
+reuse. The requested window is never silently rounded to obtain a cache hit. Windows requiring more than 512 intervals
+per series use the original paginated collector without incremental persistence to bound cache fan-out.
+
+Interval entries share `maxEntries` and `maxBytes` with other evidence. Size these limits for the working set: 100 Lambda
+functions with 4 metric series and 8 daily/edge intervals need about 3200 metric entries, plus catalog and dataset
+entries. The default 1000-entry limit can evict useful intervals in larger fleets and reduce reuse. Storage limits
+remain enforced; this feature does not increase the established defaults. Sum and SampleCount points remain separate,
+so Lambda duration stays sample-weighted when reused and newly collected intervals are combined.
+
+Metric usage appears through the existing `aws: attempt` diagnostic sink with `type: 'metric-cache'`: `cacheHits` counts
+reused intervals, `datapointsReused` and `datapointsFetched` count logical points delivered from reused and collected
+intervals, and `queryDatapointsAvoided` counts expected metric-period slots supplied by cache. `requestsAvoided` is a
+conservative lower bound: the original initial-request count when the whole metric call is reused, otherwise zero.
+It excludes pagination, retries, and additional savings from cross-dataset coalescing. Existing physical attempt events
+remain authoritative for actual request and quota costs. Metric telemetry does not include names, dimensions,
+credentials, or datapoint values.
+
+A synthetic HTTP comparison with 2 ALBs over 14 complete days collected 28 datapoints in 1 cold request. Repeating the
+same window added no CloudWatch request, even with the derived dataset TTL set to zero. The next day collected 6
+missing/revalidation datapoints in 1 request, versus 28 in full-window collection. A late revised activity point changed
+the finding, and final providers, evaluations, and diagnostics matched the uncached result. This fixture demonstrates
+request reuse and a 78.6% rollover datapoint reduction; it is not a live-account latency benchmark.
+
 ## Public pricing
 
 Public pricing has no customer authorization key. The current implementation caches the normalized AmazonVPC VPC

--- a/packages/sdk/src/providers/aws/evidence.ts
+++ b/packages/sdk/src/providers/aws/evidence.ts
@@ -22,6 +22,7 @@ import {
   throwIfAwsExecutionAborted,
   withAwsDiscoveryExecution,
 } from './execution.js';
+import { withCloudWatchMetricPlanning } from './metric-planner.js';
 import { withAwsServiceCallBudget } from './request.js';
 
 type EvidenceContext = {
@@ -45,13 +46,14 @@ export const fingerprintAwsEvidence = (value: unknown): string =>
 /**
  * Configures explicit reusable evidence under a resolved, immutable credential session.
  * @param options - Cache policy, selected target, and diagnostic logger.
- * @param run - Scan whose rules are evaluated independently of evidence reuse.
+ * @param execute - Scan whose rules are evaluated independently of evidence reuse.
  * @returns The scan result under its own authorization context.
  */
 export const withAwsEvidenceCache = async <T>(
   options: { cache?: AwsEvidenceCacheOptions; target: AwsDiscoveryTarget; debugLogger?: (message: string) => void },
-  run: () => Promise<T>,
+  execute: () => Promise<T>,
 ): Promise<T> => {
+  const run = () => withCloudWatchMetricPlanning(execute);
   if (!options.cache) return run();
   const settings = options.cache;
   for (const ttl of [

--- a/packages/sdk/src/providers/aws/execution.ts
+++ b/packages/sdk/src/providers/aws/execution.ts
@@ -90,6 +90,13 @@ export const emitAwsRequestTelemetry = (event: Record<string, unknown>): void =>
 export const getAwsExecutionSignal = (): AbortSignal | undefined => executionContext.getStore()?.controller.signal;
 
 /**
+ * Retains the caller's diagnostic sink when shared work owns an independent execution.
+ * @returns The current execution logger, or undefined when diagnostics are disabled.
+ */
+export const getAwsExecutionDebugLogger = (): ((message: string) => void) | undefined =>
+  executionContext.getStore()?.debugLogger;
+
+/**
  * Returns the deadline that bounds the active discovery execution and its request leases.
  *
  * @returns The deadline as a Unix timestamp in milliseconds, or undefined outside discovery.

--- a/packages/sdk/src/providers/aws/metric-cache.ts
+++ b/packages/sdk/src/providers/aws/metric-cache.ts
@@ -1,0 +1,158 @@
+import { getAwsEvidenceTtl, isAwsEvidenceCacheEnabled, loadAwsCachedEvidence } from './evidence.js';
+import { emitAwsRequestTelemetry, getAwsDiscoveryTimestamp } from './execution.js';
+import { planCloudWatchSignals } from './metric-planner.js';
+import type { CloudWatchMetricEvidence, CloudWatchMetricQuery } from './resources/cloudwatch.js';
+import { mapWithConcurrency } from './resources/utils.js';
+
+const DAY_MS = 86_400_000;
+const RECENT_OVERLAP_MS = 3 * DAY_MS;
+const RECENT_TTL_MS = 300_000;
+const HISTORICAL_TTL_MS = 7 * DAY_MS;
+const MAX_INTERVALS_PER_QUERY = 512;
+
+type Request = { region: string; startTime: Date; endTime: Date; queries: CloudWatchMetricQuery[] };
+type Fetch = (request: Request) => Promise<Map<string, CloudWatchMetricEvidence>>;
+
+const intervalWidth = (period: number): number => Math.max(period, Math.floor(DAY_MS / period) * period);
+
+const intervals = (start: number, end: number, period: number): Array<{ startTime: Date; endTime: Date }> => {
+  const phase = start % period;
+  const width = intervalWidth(period);
+  const result = [];
+  for (let cursor = start; cursor < end; ) {
+    const next = Math.min(end, (Math.floor((cursor - phase) / width) + 1) * width + phase);
+    result.push({ startTime: new Date(cursor), endTime: new Date(next) });
+    cursor = next;
+  }
+  return result;
+};
+
+const validEvidence = (value: unknown): value is CloudWatchMetricEvidence => {
+  if (!value || typeof value !== 'object') return false;
+  const evidence = value as CloudWatchMetricEvidence;
+  return (
+    evidence.status === 'Complete' &&
+    Array.isArray(evidence.points) &&
+    Array.isArray(evidence.messages) &&
+    Number.isInteger(evidence.attempts) &&
+    evidence.attempts > 0 &&
+    Number.isFinite(Date.parse(evidence.window?.startTime)) &&
+    Number.isFinite(Date.parse(evidence.window?.endTime)) &&
+    Number.isInteger(evidence.window?.periodSeconds) &&
+    evidence.window.periodSeconds > 0 &&
+    evidence.coverage?.observedPoints === evidence.points.length &&
+    evidence.points.every((point) => Number.isFinite(point.value) && Number.isFinite(Date.parse(point.timestamp)))
+  );
+};
+
+/**
+ * Reuses complete metric intervals under the established AWS evidence scope and plans only misses.
+ * @param request - Exact caller window and full metric identities with caller-owned IDs.
+ * @param fetch - Existing paginated collector, retaining query and physical request budgets.
+ * @param baselineRequests - Minimum initial requests for full-window collection, excluding pagination and retries.
+ * @returns Evidence for the original window, including incomplete interval status and raw weighted inputs.
+ */
+export const fetchCachedCloudWatchSignals = async (
+  request: Request,
+  fetch: Fetch,
+  baselineRequests: number,
+): Promise<Map<string, CloudWatchMetricEvidence>> => {
+  if (!isAwsEvidenceCacheEnabled()) return planCloudWatchSignals(request, fetch);
+  const timestamp = getAwsDiscoveryTimestamp();
+  let cacheHits = 0;
+  let datapointsReused = 0;
+  let datapointsFetched = 0;
+  let queryDatapointsAvoided = 0;
+  let allIntervalsReused = true;
+  // Leave room for other dataset loaders while retaining enough lookups to pack 500-query requests.
+  const maxIntervals = request.queries.reduce((maximum, query) => {
+    const period = query.period * 1000;
+    const phase = request.startTime.getTime() % period;
+    const width = intervalWidth(period);
+    return Math.max(
+      maximum,
+      Math.ceil((request.endTime.getTime() - phase) / width) -
+        Math.floor((request.startTime.getTime() - phase) / width),
+    );
+  }, 1);
+  // Unusually long caller windows retain the existing paginated collector without unbounded cache fan-out.
+  if (maxIntervals > MAX_INTERVALS_PER_QUERY) return planCloudWatchSignals(request, fetch);
+  const concurrency = Math.max(1, Math.min(500, Math.floor(7000 / maxIntervals)));
+  const results = await mapWithConcurrency(request.queries, concurrency, async (query) => {
+    const { id, ...metric } = query;
+    const identity = {
+      ...metric,
+      dimensions: [...metric.dimensions].sort((a, b) => a.Name.localeCompare(b.Name) || a.Value.localeCompare(b.Value)),
+    };
+    const windows = intervals(request.startTime.getTime(), request.endTime.getTime(), query.period * 1000);
+    const segments = await Promise.all(
+      windows.map(async (window) => {
+        const start = window.startTime.toISOString();
+        const end = window.endTime.toISOString();
+        const recent = timestamp - window.endTime.getTime() < RECENT_OVERLAP_MS;
+        const result = await loadAwsCachedEvidence({
+          datasetKey: 'metric-buckets',
+          region: request.region,
+          key: ['cloudwatch-metric-buckets-v1', request.region, identity, start, end],
+          ttlMs: getAwsEvidenceTtl('metric-buckets', recent ? RECENT_TTL_MS : HISTORICAL_TTL_MS),
+          validate: (value): value is CloudWatchMetricEvidence =>
+            validEvidence(value) &&
+            value.window.startTime === start &&
+            value.window.endTime === end &&
+            value.window.periodSeconds === query.period,
+          load: async () => {
+            const values = await planCloudWatchSignals({ ...request, ...window, queries: [query] }, fetch);
+            const value = values.get(id);
+            if (!value) throw new Error(`CloudWatch evidence missing for requested query ${id}.`);
+            return { value, complete: value.status === 'Complete', observedAt: end, observationWindow: { start, end } };
+          },
+        });
+        if (result.provenance.source === 'cache') {
+          cacheHits += 1;
+          datapointsReused += result.value.points.length;
+          queryDatapointsAvoided += result.value.coverage.expectedPoints;
+        } else {
+          allIntervalsReused = false;
+          datapointsFetched += result.value.points.length;
+        }
+        return result.value;
+      }),
+    );
+    const points = segments.flatMap((segment) => segment.points);
+    const failed =
+      segments.find((segment) => segment.status === 'Forbidden') ??
+      segments.find((segment) => segment.status !== 'Complete');
+    return [
+      id,
+      {
+        status: failed?.status ?? 'Complete',
+        points,
+        window: {
+          startTime: request.startTime.toISOString(),
+          endTime: request.endTime.toISOString(),
+          periodSeconds: query.period,
+        },
+        coverage: {
+          expectedPoints: Math.ceil((request.endTime.getTime() - request.startTime.getTime()) / (query.period * 1000)),
+          observedPoints: points.length,
+        },
+        attempts: Math.max(...segments.map((segment) => segment.attempts)),
+        messages: [
+          ...new Map(
+            segments.flatMap((segment) => segment.messages).map((message) => [JSON.stringify(message), message]),
+          ).values(),
+        ],
+      } satisfies CloudWatchMetricEvidence,
+    ] as const;
+  });
+  emitAwsRequestTelemetry({
+    type: 'metric-cache',
+    region: request.region,
+    cacheHits,
+    datapointsReused,
+    datapointsFetched,
+    queryDatapointsAvoided,
+    requestsAvoided: allIntervalsReused ? baselineRequests : 0,
+  });
+  return new Map(results);
+};

--- a/packages/sdk/src/providers/aws/metric-planner.ts
+++ b/packages/sdk/src/providers/aws/metric-planner.ts
@@ -1,0 +1,355 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import {
+  awaitAwsExecution,
+  getAwsDiscoveryTimestamp,
+  getAwsExecutionDeadline,
+  getAwsExecutionDebugLogger,
+  getAwsExecutionSignal,
+  runOutsideAwsExecution,
+  throwIfAwsExecutionAborted,
+  withAwsDiscoveryExecution,
+} from './execution.js';
+import type { CloudWatchMetricEvidence, CloudWatchMetricQuery } from './resources/cloudwatch.js';
+
+const MAX_RETAINED_QUERIES = 8192;
+const MAX_ACTIVE_REQUESTS = 2;
+const FLUSH_DELAY_MS = 5;
+
+type MetricRequest = {
+  region: string;
+  startTime: Date;
+  endTime: Date;
+  queries: CloudWatchMetricQuery[];
+};
+type MetricFetch = (request: MetricRequest) => Promise<Map<string, CloudWatchMetricEvidence>>;
+type Waiter = {
+  request: MetricRequest;
+  fetch: MetricFetch;
+  resolve: (result: Map<string, CloudWatchMetricEvidence>) => void;
+  reject: (error: unknown) => void;
+  results: Map<string, CloudWatchMetricEvidence>;
+  active: boolean;
+  observationTimestamp: number;
+  deadline?: number;
+  debugLogger?: (message: string) => void;
+  onSettled: Set<() => void>;
+  runInContext: <T>(run: () => T) => T;
+};
+type Consumer = { waiter: Waiter; query: CloudWatchMetricQuery };
+type Segment = { start: number; end: number; query: CloudWatchMetricQuery; consumers: Consumer[] };
+type Planner = {
+  pending: Waiter[];
+  queued: Segment[][];
+  active: number;
+  retainedQueries: number;
+  capacity: ReturnType<typeof createCapacityNotification>;
+  capacityScheduled: boolean;
+  timer?: ReturnType<typeof setTimeout>;
+};
+const context = new AsyncLocalStorage<Planner>();
+
+const createCapacityNotification = (): { promise: Promise<void>; resolve: () => void } => {
+  let resolve = () => {};
+  const promise = new Promise<void>((notify) => {
+    resolve = notify;
+  });
+  return { promise, resolve };
+};
+
+const metricIdentity = (query: CloudWatchMetricQuery, start: number, end: number): string =>
+  JSON.stringify([
+    query.namespace,
+    query.metricName,
+    [...query.dimensions].sort(
+      (left, right) => left.Name.localeCompare(right.Name) || left.Value.localeCompare(right.Value),
+    ),
+    query.period,
+    query.stat,
+    start % (query.period * 1000),
+    // A partial final period must retain its exact aggregation window.
+    (end - start) % (query.period * 1000) === 0 ? null : [start, end],
+  ]);
+
+const sliceEvidence = (evidence: CloudWatchMetricEvidence, consumer: Consumer): CloudWatchMetricEvidence => {
+  const { request } = consumer.waiter;
+  const start = +request.startTime;
+  const end = +request.endTime;
+  const points = evidence.points.filter(
+    (point) => Date.parse(point.timestamp) >= start && Date.parse(point.timestamp) < end,
+  );
+  return {
+    ...evidence,
+    points,
+    messages: evidence.messages.map((message) => ({ ...message })),
+    window: {
+      startTime: request.startTime.toISOString(),
+      endTime: request.endTime.toISOString(),
+      periodSeconds: consumer.query.period,
+    },
+    coverage: {
+      expectedPoints: Math.ceil((end - start) / (consumer.query.period * 1000)),
+      observedPoints: new Set(
+        points.map((point) => Math.floor((Date.parse(point.timestamp) - start) / (consumer.query.period * 1000))),
+      ).size,
+    },
+  };
+};
+
+// Merge only the union of requested intervals, then batch metrics sharing that exact union.
+const planWindows = (consumers: Consumer[]): Segment[][] => {
+  const metrics = new Map<string, Segment[]>();
+  for (const consumer of consumers) {
+    if (!consumer.waiter.active) continue;
+    const { query, waiter } = consumer;
+    const start = +waiter.request.startTime;
+    const key = metricIdentity(query, start, +waiter.request.endTime);
+    const segments = metrics.get(key) ?? [];
+    segments.push({ start, end: +waiter.request.endTime, query, consumers: [consumer] });
+    metrics.set(key, segments);
+  }
+  const windows = new Map<string, Segment[]>();
+  for (const segments of metrics.values()) {
+    const merged: Segment[] = [];
+    for (const segment of segments.sort((left, right) => left.start - right.start)) {
+      const previous = merged.at(-1);
+      if (previous && segment.start <= previous.end) {
+        previous.end = Math.max(previous.end, segment.end);
+        previous.consumers.push(...segment.consumers);
+      } else merged.push(segment);
+    }
+    for (const segment of merged) {
+      const key = `${segment.start}:${segment.end}`;
+      const window = windows.get(key) ?? [];
+      window.push(segment);
+      windows.set(key, window);
+    }
+  }
+  return [...windows.values()];
+};
+
+const executeWindow = async (segments: Segment[]): Promise<void> => {
+  const firstSegment = segments[0];
+  const first = firstSegment?.consumers[0]?.waiter;
+  if (!firstSegment || !first) return;
+  const consumers = segments.flatMap((segment) => segment.consumers);
+  const deadline = Math.max(...consumers.map((consumer) => consumer.waiter.deadline ?? Date.now() + 300_000));
+  const controller = new AbortController();
+  const activeWaiters = new Set(consumers.map((consumer) => consumer.waiter));
+  const notifications = new Map(
+    [...activeWaiters].map((waiter) => [
+      waiter,
+      () => {
+        activeWaiters.delete(waiter);
+        if (activeWaiters.size === 0) controller.abort(new DOMException('All metric waiters cancelled.', 'AbortError'));
+      },
+    ]),
+  );
+  for (const [waiter, notification] of notifications) waiter.onSettled.add(notification);
+  try {
+    // Preserve the originating credentials and request budget, with independent transport ownership.
+    const results = await first.runInContext(() =>
+      runOutsideAwsExecution(() =>
+        withAwsDiscoveryExecution(
+          {
+            signal: controller.signal,
+            observationTimestamp: first.observationTimestamp,
+            debugLogger: first.debugLogger,
+            timeoutMs: Math.max(1, Math.min(2_147_483_647, deadline - Date.now())),
+          },
+          () =>
+            first.fetch({
+              region: first.request.region,
+              startTime: new Date(firstSegment.start),
+              endTime: new Date(firstSegment.end),
+              queries: segments.map((segment, index) => ({ ...segment.query, id: `m${index}` })),
+            }),
+        ),
+      ),
+    );
+    segments.forEach((segment, index) => {
+      const evidence = results.get(`m${index}`);
+      if (!evidence) throw new Error(`CloudWatch evidence missing for requested query m${index}.`);
+      for (const consumer of segment.consumers) {
+        if (!consumer.waiter.active) continue;
+        consumer.waiter.results.set(consumer.query.id, sliceEvidence(evidence, consumer));
+        if (consumer.waiter.results.size === consumer.waiter.request.queries.length) {
+          consumer.waiter.resolve(
+            new Map(
+              consumer.waiter.request.queries.map((query) => [
+                query.id,
+                consumer.waiter.results.get(query.id) as CloudWatchMetricEvidence,
+              ]),
+            ),
+          );
+        }
+      }
+    });
+  } catch (error) {
+    for (const consumer of consumers) consumer.waiter.reject(error);
+  } finally {
+    for (const [waiter, notification] of notifications) waiter.onSettled.delete(notification);
+  }
+};
+
+const pump = (planner: Planner): void => {
+  while (planner.active < MAX_ACTIVE_REQUESTS && planner.queued.length > 0) {
+    const queued = planner.queued.shift();
+    if (!queued) break;
+    // A cancelled waiter may have been the bridge joining two otherwise separate intervals.
+    const [segments, ...remaining] = planWindows(queued.flatMap((segment) => segment.consumers));
+    planner.queued.unshift(...remaining);
+    if (!segments) continue;
+    planner.active += 1;
+    void executeWindow(segments).finally(() => {
+      planner.active -= 1;
+      pump(planner);
+    });
+  }
+};
+
+const flush = (planner: Planner): void => {
+  planner.timer = undefined;
+  const pending = planner.pending.splice(0);
+  while (pending.length > 0) {
+    const first = pending.shift();
+    if (!first) break;
+    const waiters = [first];
+    for (let index = 0; index < pending.length; ) {
+      const other = pending[index];
+      if (other && other.fetch === first.fetch && other.request.region === first.request.region) {
+        waiters.push(other);
+        pending.splice(index, 1);
+      } else index += 1;
+    }
+    planner.queued.push(
+      ...planWindows(waiters.flatMap((waiter) => waiter.request.queries.map((query) => ({ waiter, query })))),
+    );
+  }
+  pump(planner);
+};
+
+/**
+ * Collects metric requests within a scan with a 5 ms flush delay, two active requests and at most 8192 retained queries.
+ * Shared cache loaders can outlive the scan; their own waiter signals control planner cleanup.
+ * @param run - Scan whose concurrent metric lookups may share requests.
+ * @returns The scan result.
+ */
+export const withCloudWatchMetricPlanning = <T>(run: () => Promise<T>): Promise<T> =>
+  context.run(
+    {
+      pending: [],
+      queued: [],
+      active: 0,
+      retainedQueries: 0,
+      capacity: createCapacityNotification(),
+      capacityScheduled: false,
+    },
+    run,
+  );
+
+/**
+ * Plans metric requests while preserving each caller's query identities and requested intervals.
+ * @param request - Region, observation window and caller-owned metric queries.
+ * @param fetch - Stable transport function that owns AWS batching, pagination and retries.
+ * @returns Evidence for each requested query, waiting for capacity and splitting inputs larger than 8192 queries.
+ */
+export const planCloudWatchSignals = async (
+  request: MetricRequest,
+  fetch: MetricFetch,
+): Promise<Map<string, CloudWatchMetricEvidence>> => {
+  const planner = context.getStore();
+  if (!planner) return fetch(request);
+  if (
+    !Number.isFinite(+request.startTime) ||
+    !Number.isFinite(+request.endTime) ||
+    request.endTime <= request.startTime
+  ) {
+    return Promise.reject(new RangeError('CloudWatch observation windows must have a finite start before the end.'));
+  }
+  const ids = new Set<string>();
+  for (const query of request.queries) {
+    if (!Number.isInteger(query.period) || query.period <= 0)
+      return Promise.reject(new RangeError('CloudWatch metric periods must be positive integers.'));
+    if (ids.has(query.id)) return Promise.reject(new RangeError(`Duplicate CloudWatch query ID: ${query.id}`));
+    ids.add(query.id);
+  }
+  if (request.queries.length === 0) return Promise.resolve(new Map());
+  if (request.queries.length > MAX_RETAINED_QUERIES) {
+    const results = new Map<string, CloudWatchMetricEvidence>();
+    for (let index = 0; index < request.queries.length; index += MAX_RETAINED_QUERIES) {
+      const batch = await planCloudWatchSignals(
+        { ...request, queries: request.queries.slice(index, index + MAX_RETAINED_QUERIES) },
+        fetch,
+      );
+      for (const [id, evidence] of batch) results.set(id, evidence);
+    }
+    return results;
+  }
+  while (planner.retainedQueries + request.queries.length > MAX_RETAINED_QUERIES) {
+    // Admission waits share one capacity notification rather than retaining a separate planner queue.
+    await awaitAwsExecution(planner.capacity.promise);
+  }
+  throwIfAwsExecutionAborted();
+  return new Promise((resolve, reject) => {
+    const signal = getAwsExecutionSignal();
+    planner.retainedQueries += request.queries.length;
+    const settle = () => {
+      if (!waiter.active) return false;
+      waiter.active = false;
+      planner.retainedQueries -= request.queries.length;
+      if (!planner.capacityScheduled) {
+        planner.capacityScheduled = true;
+        queueMicrotask(() => {
+          planner.capacityScheduled = false;
+          const previous = planner.capacity;
+          planner.capacity = createCapacityNotification();
+          previous.resolve();
+        });
+      }
+      signal?.removeEventListener('abort', onAbort);
+      const index = planner.pending.indexOf(waiter);
+      if (index >= 0) planner.pending.splice(index, 1);
+      planner.queued = planner.queued
+        .map((segments) =>
+          segments
+            .map((segment) => ({
+              ...segment,
+              consumers: segment.consumers.filter((consumer) => consumer.waiter.active),
+            }))
+            .filter((segment) => segment.consumers.length > 0),
+        )
+        .filter((segments) => segments.length > 0);
+      if (planner.pending.length === 0) {
+        clearTimeout(planner.timer);
+        planner.timer = undefined;
+      }
+      for (const notify of waiter.onSettled) notify();
+      return true;
+    };
+    const waiter: Waiter = {
+      request,
+      fetch,
+      results: new Map(),
+      active: true,
+      onSettled: new Set(),
+      runInContext: AsyncLocalStorage.snapshot(),
+      observationTimestamp: getAwsDiscoveryTimestamp(),
+      deadline: getAwsExecutionDeadline(),
+      debugLogger: getAwsExecutionDebugLogger(),
+      resolve: (result) => {
+        if (settle()) resolve(result);
+      },
+      reject: (error) => {
+        if (settle()) reject(error);
+      },
+    };
+    const onAbort = () => waiter.reject(signal?.reason);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    planner.pending.push(waiter);
+    planner.timer ??= setTimeout(() => flush(planner), FLUSH_DELAY_MS);
+  });
+};

--- a/packages/sdk/src/providers/aws/resources/cloudwatch.ts
+++ b/packages/sdk/src/providers/aws/resources/cloudwatch.ts
@@ -1,6 +1,7 @@
 import { GetMetricDataCommand, type MessageData } from '@aws-sdk/client-cloudwatch';
 import { createCloudWatchClient } from '../client.js';
 import { waitForAwsDelay } from '../execution.js';
+import { fetchCachedCloudWatchSignals } from '../metric-cache.js';
 import { chunkItems, mapWithConcurrency, withAwsServiceErrorContext } from './utils.js';
 
 const CLOUDWATCH_METRIC_QUERY_BATCH_SIZE = 500;
@@ -106,7 +107,7 @@ const appendMessages = (
  * @param options - Region, explicit observation window, and queries with unique caller-owned IDs.
  * @returns One evidence record per query, with status, normalized points, coverage and AWS diagnostics.
  */
-export const fetchCloudWatchSignals = async (options: {
+const fetchCloudWatchSignalsLive = async (options: {
   region: string;
   startTime: Date;
   endTime: Date;
@@ -254,4 +255,19 @@ export const fetchCloudWatchSignals = async (options: {
       return [query.id, evidence];
     }),
   );
+};
+
+/**
+ * Retrieves exact-window metric evidence with scoped incremental reuse and bounded query planning.
+ * @param options - Region, observation window, and queries with unique caller-owned IDs.
+ * @returns One complete or explicitly incomplete evidence record per requested query.
+ */
+export const fetchCloudWatchSignals = async (options: {
+  region: string;
+  startTime: Date;
+  endTime: Date;
+  queries: CloudWatchMetricQuery[];
+}): Promise<Map<string, CloudWatchMetricEvidence>> => {
+  const batches = createMetricBatches(options.queries, options.startTime, options.endTime);
+  return fetchCachedCloudWatchSignals(options, fetchCloudWatchSignalsLive, batches.length);
 };

--- a/packages/sdk/test/discovery-http-integration.test.ts
+++ b/packages/sdk/test/discovery-http-integration.test.ts
@@ -38,7 +38,12 @@ const xmlResponse = (operation: string, content: string) => ({
     ),
   },
 });
-type ElbScenario = { names: string[]; includeTargets: boolean; metricCases: Record<string, string> };
+type ElbScenario = {
+  names: string[];
+  includeTargets: boolean;
+  metricCases: Record<string, string>;
+  metricValue?: (name: string, timestamp: number) => number;
+};
 let elbScenario: ElbScenario | undefined;
 const useElbScenario = (names = Array.from({ length: 10 }, (_, index) => `alb-${index}`)): ElbScenario => {
   // Freeze the observation date while allowing admission waits to refill quota tokens.
@@ -54,6 +59,7 @@ let denyIdentity: boolean;
 let includeNewVolume: boolean;
 let viewScope: string | undefined;
 let requests: Array<{ hostname: string; operation: string }>;
+let metricRequests: Array<{ start: number; end: number; queryCount: number; datapoints: number }>;
 let unexpected: string[];
 let debugMessages: string[];
 let admissionDirectory: string;
@@ -80,6 +86,7 @@ beforeEach(() => {
   includeNewVolume = false;
   viewScope = undefined;
   requests = [];
+  metricRequests = [];
   unexpected = [];
   debugMessages = [];
   admissionDirectory = mkdtempSync(join(tmpdir(), 'cloudburn-discovery-http-'));
@@ -276,29 +283,42 @@ beforeEach(() => {
       }
     }
     if (elbScenario && request.hostname === 'monitoring.eu-west-1.amazonaws.com' && operation === 'GetMetricData') {
-      const { metricCases } = elbScenario;
+      const { metricCases, metricValue } = elbScenario;
       const input = JSON.parse(body) as {
+        StartTime: number;
+        EndTime: number;
         MetricDataQueries: Array<{
           Id: string;
-          MetricStat: { Metric: { Dimensions: Array<{ Name: string; Value: string }> } };
+          MetricStat: { Period: number; Metric: { Dimensions: Array<{ Name: string; Value: string }> } };
         }>;
       };
-      return jsonResponse({
+      const response = {
         MetricDataResults: input.MetricDataQueries.flatMap((query) => {
           const name = query.MetricStat.Metric.Dimensions[0]?.Value.split('/')[1] ?? '';
           const status = metricCases[name] ?? 'Complete';
           if (status === 'Missing') return [];
+          const timestamps =
+            status === 'Empty'
+              ? []
+              : Array.from(
+                  { length: Math.ceil((input.EndTime - input.StartTime) / query.MetricStat.Period) },
+                  (_, index) => input.StartTime + index * query.MetricStat.Period,
+                );
           return {
             Id: query.Id,
             StatusCode: status === 'Empty' ? 'Complete' : status,
-            Timestamps:
-              status === 'Empty'
-                ? []
-                : Array.from({ length: 14 }, (_, index) => Date.parse('2026-08-24T00:00:00Z') / 1000 + index * 86_400),
-            Values: status === 'Empty' ? [] : Array.from({ length: 14 }, () => 5),
+            Timestamps: timestamps,
+            Values: timestamps.map((timestamp) => metricValue?.(name, timestamp) ?? 5),
           };
         }),
+      };
+      metricRequests.push({
+        start: input.StartTime,
+        end: input.EndTime,
+        queryCount: input.MetricDataQueries.length,
+        datapoints: response.MetricDataResults.reduce((sum, result) => sum + result.Values.length, 0),
       });
+      return jsonResponse(response);
     }
     const description = `${request.method} ${request.hostname}${request.path}`;
     unexpected.push(description);
@@ -545,6 +565,77 @@ it('reports denied required AWS evidence as unavailable rather than a passed che
 });
 
 describe('ELB request activity', () => {
+  it('reuses historical metrics on rollover while late activity matches a full-window scan', {
+    timeout: 20_000,
+  }, async () => {
+    const scenario = useElbScenario(['idle', 'late-activity']);
+    scenario.includeTargets = true;
+    const client = new CloudBurnClient({ debugLogger: (message) => debugMessages.push(message) });
+    const scan = {
+      target: { mode: 'region' as const, region },
+      cache: {
+        directory: join(admissionDirectory, 'metric-evidence'),
+        authorizationContext: 'synthetic-policy-v1',
+        ttlMs: { datasets: { 'aws-ec2-load-balancer-request-activity': 0 } },
+      },
+      config: { discovery: { enabledRules: ['CLDBRN-AWS-ELB-5'] } },
+      includeEvaluationResources: true,
+    };
+    const first = await client.discover(scan);
+    expect(first.providers[0]?.rules[0]?.findings).toEqual([identity('idle'), identity('late-activity')]);
+    expect(metricRequests).toEqual([
+      {
+        start: Date.parse('2026-08-24T00:00:00Z') / 1000,
+        end: Date.parse('2026-09-07T00:00:00Z') / 1000,
+        queryCount: 2,
+        datapoints: 28,
+      },
+    ]);
+
+    const repeated = await client.discover(scan);
+    expect(repeated.providers).toEqual(first.providers);
+    expect(repeated.evaluations).toEqual(first.evaluations);
+    expect(metricRequests).toHaveLength(1);
+
+    // A revised closed day changes the late-activity ALB's 14-day average from 5 to above 10.
+    scenario.metricValue = (name, timestamp) =>
+      name === 'late-activity' && timestamp === Date.parse('2026-09-06T00:00:00Z') / 1000 ? 200 : 5;
+    vi.setSystemTime(new Date('2026-09-08T12:00:00Z'));
+    const incremental = await client.discover(scan);
+    expect(incremental.providers[0]?.rules[0]?.findings).toEqual([identity('idle')]);
+    expect(metricRequests).toHaveLength(2);
+    expect(metricRequests[1]).toEqual({
+      start: Date.parse('2026-09-05T00:00:00Z') / 1000,
+      end: Date.parse('2026-09-08T00:00:00Z') / 1000,
+      queryCount: 2,
+      datapoints: 6,
+    });
+    expect(
+      debugMessages
+        .filter((message) => message.startsWith('aws: attempt '))
+        .map((message) => JSON.parse(message.slice(13))),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: 'metric-cache',
+        cacheHits: 22,
+        datapointsReused: 22,
+        datapointsFetched: 6,
+      }),
+    );
+
+    const baseline = await client.discover({ ...scan, cache: { ...scan.cache, mode: 'off' } });
+    expect(incremental.providers).toEqual(baseline.providers);
+    expect(incremental.evaluations).toEqual(baseline.evaluations);
+    expect(incremental.diagnostics).toEqual(baseline.diagnostics);
+    expect(metricRequests).toHaveLength(3);
+    expect(metricRequests[2]).toEqual({
+      start: Date.parse('2026-08-25T00:00:00Z') / 1000,
+      end: Date.parse('2026-09-08T00:00:00Z') / 1000,
+      queryCount: 2,
+      datapoints: 28,
+    });
+  });
+
   it('loads inventory plus activity for ten ALBs with eleven metadata calls, counting health and metrics separately', async () => {
     useElbScenario();
     const result = await discover('CLDBRN-AWS-ELB-5');

--- a/packages/sdk/test/discovery-metric-http-integration.test.ts
+++ b/packages/sdk/test/discovery-metric-http-integration.test.ts
@@ -254,7 +254,7 @@ it('reuses a rolling observation window across minutes and refreshes at its fres
   );
 });
 
-it('recollects derived metrics when the inventory loader version changes with identical normalized inventory', {
+it('rebuilds derived metrics after inventory version changes while reusing compatible metric buckets', {
   timeout: 20_000,
 }, async () => {
   metricScenario = 'lambda';
@@ -267,10 +267,7 @@ it('recollects derived metrics when the inventory loader version changes with id
     definition.loaderVersion = `${originalVersion}-test-revision`;
     const second = await discoverCachedLambda();
     expect(lambdaInventoryCalls).toBe(2);
-    expect(metricWindows).toEqual([
-      { start: '2026-08-31T12:00:00.000Z', end: '2026-09-07T12:00:00.000Z' },
-      { start: '2026-08-31T12:00:00.000Z', end: '2026-09-07T12:00:00.000Z' },
-    ]);
+    expect(metricWindows).toEqual([{ start: '2026-08-31T12:00:00.000Z', end: '2026-09-07T12:00:00.000Z' }]);
     expect(second.evidence).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -278,6 +275,7 @@ it('recollects derived metrics when the inventory loader version changes with id
           source: 'live',
           complete: true,
         }),
+        expect.objectContaining({ datasetKey: 'metric-buckets', source: 'cache', complete: true }),
       ]),
     );
   } finally {

--- a/packages/sdk/test/discovery-pricing-http-integration.test.ts
+++ b/packages/sdk/test/discovery-pricing-http-integration.test.ts
@@ -77,8 +77,8 @@ beforeEach(() => {
       const startTime = input.StartTime;
       return response(
         JSON.stringify({
-          MetricDataResults: ['tgwIn0', 'tgwOut0'].map((Id) => ({
-            Id,
+          MetricDataResults: input.MetricDataQueries.map((query: { Id: string }) => ({
+            Id: query.Id,
             StatusCode: 'Complete',
             Timestamps: Array.from({ length: 30 }, (_, index) => startTime + index * 86_400),
             Values: Array.from({ length: 30 }, () => 0),

--- a/packages/sdk/test/providers/aws-metric-cache.test.ts
+++ b/packages/sdk/test/providers/aws-metric-cache.test.ts
@@ -1,0 +1,291 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CloudWatchClient, type GetMetricDataCommand } from '@aws-sdk/client-cloudwatch';
+import { LambdaClient } from '@aws-sdk/client-lambda';
+import { STSClient } from '@aws-sdk/client-sts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMemoryEvidenceCacheStore } from '../../src/evidence-cache.js';
+import { withAwsClientCredentials } from '../../src/providers/aws/client.js';
+import { withAwsEvidenceCache } from '../../src/providers/aws/evidence.js';
+import { getAwsExecutionSignal, withAwsDiscoveryExecution } from '../../src/providers/aws/execution.js';
+import { type CloudWatchMetricQuery, fetchCloudWatchSignals } from '../../src/providers/aws/resources/cloudwatch.js';
+import { hydrateAwsLambdaFunctionMetrics } from '../../src/providers/aws/resources/lambda.js';
+import type { AwsEvidenceCacheOptions } from '../../src/types.js';
+
+const day = 86_400_000;
+const startTime = new Date('2026-08-25T00:00:00Z');
+const endTime = new Date('2026-09-08T00:00:00Z');
+const query = {
+  id: 'cpu',
+  namespace: 'AWS/EC2',
+  metricName: 'CPUUtilization',
+  dimensions: [{ Name: 'InstanceId', Value: 'i-synthetic' }],
+  period: 86400,
+  stat: 'Average' as const,
+};
+
+describe('incremental CloudWatch evidence', () => {
+  let store = createMemoryEvidenceCacheStore();
+  let pointValue: (
+    time: Date,
+    metric: NonNullable<GetMetricDataCommand['input']['MetricDataQueries']>[number],
+  ) => number | undefined;
+  let status: string;
+  let admissionDirectory: string;
+  let beforeResponse: () => Promise<void>;
+  let debugMessages: string[];
+  const debugLogger = (message: string) => debugMessages.push(message);
+  let requests: GetMetricDataCommand['input'][];
+  const inScan = <T>(run: () => Promise<T>, cache: Partial<AwsEvidenceCacheOptions> = {}, signal?: AbortSignal) =>
+    withAwsClientCredentials({ accessKeyId: 'SYNTHETIC', secretAccessKey: 'synthetic', sessionToken: 'session' }, () =>
+      withAwsDiscoveryExecution({ signal, debugLogger }, () =>
+        withAwsEvidenceCache(
+          { cache: { store, ...cache }, target: { mode: 'region', region: 'eu-west-1' }, debugLogger },
+          run,
+        ),
+      ),
+    );
+  const scan = (end = endTime, metric: CloudWatchMetricQuery = query, cache: Partial<AwsEvidenceCacheOptions> = {}) =>
+    inScan(
+      () =>
+        fetchCloudWatchSignals({
+          region: 'eu-west-1',
+          startTime: new Date(end.getTime() - 14 * day),
+          endTime: end,
+          queries: [metric],
+        }),
+      cache,
+    );
+  beforeEach(() => {
+    admissionDirectory = mkdtempSync(join(tmpdir(), 'cloudburn-metric-cache-'));
+    vi.stubEnv('CLOUDBURN_AWS_ADMISSION_DIR', admissionDirectory);
+    requests = [];
+    store = createMemoryEvidenceCacheStore();
+    status = 'Complete';
+    beforeResponse = async () => {};
+    debugMessages = [];
+    pointValue = () => 1;
+    vi.useFakeTimers({ toFake: ['Date'], shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-09-08T12:00:00Z'));
+    vi.spyOn(STSClient.prototype, 'send').mockResolvedValue({
+      Account: '111111111111',
+      Arn: 'arn:aws:iam::111111111111:role/test',
+    } as never);
+    vi.spyOn(CloudWatchClient.prototype, 'send').mockImplementation(async (command) => {
+      const input = (command as GetMetricDataCommand).input;
+      requests.push(input);
+      await beforeResponse();
+      return {
+        MetricDataResults: input.MetricDataQueries?.map((entry) => {
+          const timestamps: Date[] = [];
+          for (
+            let time = input.StartTime?.getTime() ?? 0;
+            time < (input.EndTime?.getTime() ?? 0);
+            time += (entry.MetricStat?.Period ?? 86400) * 1000
+          )
+            timestamps.push(new Date(time));
+          const observed = timestamps.flatMap((time) => {
+            const value = pointValue(time, entry);
+            return value === undefined ? [] : [{ time, value }];
+          });
+          return {
+            Id: entry.Id,
+            StatusCode: status,
+            Timestamps: observed.map(({ time }) => time),
+            Values: observed.map(({ value }) => value),
+          };
+        }),
+      };
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    rmSync(admissionDirectory, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  it('reuses the same window and fetches only recent overlap plus the missing day on rollover', async () => {
+    const first = await scan();
+    expect(first.get('cpu')?.coverage).toEqual({ expectedPoints: 14, observedPoints: 14 });
+    expect(requests).toHaveLength(1);
+    const repeated = await scan();
+    expect(repeated).toEqual(first);
+    expect(requests).toHaveLength(1);
+    const telemetry = debugMessages
+      .filter((line) => line.startsWith('aws: attempt '))
+      .map((line) => JSON.parse(line.slice(13)))
+      .filter((event) => event.type === 'metric-cache');
+    expect(telemetry.at(-1)).toMatchObject({
+      cacheHits: 14,
+      datapointsReused: 14,
+      datapointsFetched: 0,
+      queryDatapointsAvoided: 14,
+      requestsAvoided: 1,
+    });
+    expect(debugMessages.join('\n')).not.toContain('i-synthetic');
+    vi.setSystemTime(new Date('2026-09-09T12:00:00Z'));
+    const next = await scan(new Date(endTime.getTime() + day));
+    expect(next.get('cpu')).toMatchObject({ status: 'Complete', coverage: { expectedPoints: 14, observedPoints: 14 } });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.StartTime?.getTime()).toBeGreaterThanOrEqual(endTime.getTime() - 3 * day);
+    expect(next.get('cpu')?.window.startTime).toBe(new Date(startTime.getTime() + day).toISOString());
+  });
+  it('replaces revised overlap points without duplicates and retains older complete buckets', async () => {
+    await scan();
+    pointValue = (time) => (time.toISOString() === '2026-09-07T00:00:00.000Z' ? 5 : 1);
+    vi.setSystemTime(new Date('2026-09-08T12:06:00Z'));
+    const revised = await scan();
+    expect(revised.get('cpu')?.points.reduce((sum, point) => sum + point.value, 0)).toBe(18);
+    expect(revised.get('cpu')?.coverage).toEqual({ expectedPoints: 14, observedPoints: 14 });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.StartTime).toEqual(new Date('2026-09-05T00:00:00Z'));
+  });
+
+  it.each([
+    'PartialData',
+    'Forbidden',
+  ])('never publishes %s intervals as complete or falls back after refresh', async (failure) => {
+    await scan();
+    status = failure;
+    const failed = await scan(endTime, query, { mode: 'refresh' });
+    expect(failed.get('cpu')?.status).toBe(failure);
+    status = 'Complete';
+    const before = requests.length;
+    const recovered = await scan();
+    expect(recovered.get('cpu')?.status).toBe('Complete');
+    expect(requests.length).toBeGreaterThan(before);
+    const after = requests.length;
+    await scan();
+    expect(requests).toHaveLength(after);
+  });
+
+  it('keeps caller IDs out of identity but separates metric dimensions, statistic, period, namespace and authorization scope', async () => {
+    await scan();
+    const renamed = await scan(endTime, { ...query, id: 'renamed' });
+    expect(renamed.get('renamed')?.coverage.observedPoints).toBe(14);
+    expect(requests).toHaveLength(1);
+    for (const changed of [
+      { ...query, dimensions: [{ Name: 'InstanceId', Value: 'i-other' }] },
+      { ...query, stat: 'Sum' as const },
+      { ...query, period: 3600 },
+      { ...query, namespace: 'Synthetic/Other' },
+      { ...query, metricName: 'NetworkOut' },
+    ]) {
+      const before = requests.length;
+      await scan(endTime, changed);
+      expect(requests.length).toBeGreaterThan(before);
+    }
+    const beforeScopeChange = requests.length;
+    await scan(endTime, query, { authorizationContext: 'changed-policy' });
+    expect(requests.length).toBeGreaterThan(beforeScopeChange);
+  });
+
+  it('preserves sample-weighted Lambda duration across daily reuse and late sample revisions', async () => {
+    const functionArn = 'arn:aws:lambda:eu-west-1:111111111111:function:synthetic';
+    vi.spyOn(LambdaClient.prototype, 'send').mockResolvedValue({
+      Functions: [{ FunctionArn: functionArn, FunctionName: 'synthetic' }],
+    } as never);
+    let revised = false;
+    pointValue = (time, metric) => {
+      const date = time.toISOString();
+      if (!['2026-09-03T12:00:00.000Z', '2026-09-07T12:00:00.000Z'].includes(date)) return undefined;
+      const first = date.startsWith('2026-09-03');
+      if (metric.MetricStat?.Metric?.MetricName === 'Duration') {
+        if (metric.MetricStat.Stat === 'SampleCount') return first ? 1 : 9;
+        return first ? 100 : revised ? 3600 : 2700;
+      }
+      return metric.MetricStat?.Metric?.MetricName === 'Errors' ? 0 : first ? 1 : 9;
+    };
+    const collect = () =>
+      hydrateAwsLambdaFunctionMetrics([
+        {
+          accountId: '111111111111',
+          arn: functionArn,
+          properties: [],
+          region: 'eu-west-1',
+          resourceType: 'lambda:function',
+          service: 'lambda',
+        },
+      ]);
+    expect((await inScan(collect))[0]?.averageDurationMsLast7Days).toBe(280);
+    expect(requests).toHaveLength(1);
+    expect((await inScan(collect))[0]?.averageDurationMsLast7Days).toBe(280);
+    expect(requests).toHaveLength(1);
+    revised = true;
+    vi.setSystemTime(new Date('2026-09-09T12:00:00Z'));
+    const incremental = await inScan(collect);
+    expect(incremental[0]?.averageDurationMsLast7Days).toBe(370);
+    // The changed leading half-day is a separate exact interval from the recent overlap.
+    expect(requests).toHaveLength(3);
+    const refreshedHours = requests
+      .slice(1)
+      .reduce(
+        (sum, request) => sum + ((request.EndTime?.getTime() ?? 0) - (request.StartTime?.getTime() ?? 0)) / 3_600_000,
+        0,
+      );
+    expect(refreshedHours).toBeLessThan(168);
+    expect(incremental).toEqual(await inScan(collect, { mode: 'off' }));
+  });
+  it('keeps a coalesced request alive when another scan still awaits one of its cached series', async () => {
+    const controller = new AbortController();
+    const gate = Promise.withResolvers<void>();
+    let sharedSignal: AbortSignal | undefined;
+    beforeResponse = async () => {
+      sharedSignal = getAwsExecutionSignal();
+      await gate.promise;
+    };
+    const other = { ...query, id: 'network', metricName: 'NetworkOut' };
+    const first = inScan(
+      () => fetchCloudWatchSignals({ region: 'eu-west-1', startTime, endTime, queries: [query, other] }),
+      {},
+      controller.signal,
+    );
+    const cancelled = expect(first).rejects.toThrow('cancel-first');
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    const second = scan(endTime, other);
+    await vi.waitFor(() =>
+      expect(debugMessages.filter((line) => line.includes('evidence lookup metric-buckets'))).toHaveLength(42),
+    );
+    controller.abort(new Error('cancel-first'));
+    await cancelled;
+    expect(sharedSignal?.aborted).toBe(false);
+    gate.resolve();
+    expect((await second).get('network')?.coverage).toEqual({ expectedPoints: 14, observedPoints: 14 });
+    expect(requests).toHaveLength(1);
+  });
+
+  it('retains the existing 500-query cold request packing while cache intervals are admitted', async () => {
+    const result = await inScan(() =>
+      fetchCloudWatchSignals({
+        region: 'eu-west-1',
+        startTime: new Date(endTime.getTime() - day),
+        endTime,
+        queries: Array.from({ length: 500 }, (_, index) => ({
+          ...query,
+          id: `cpu${index}`,
+          dimensions: [{ Name: 'InstanceId', Value: `i-${index}` }],
+        })),
+      }),
+    );
+    expect(result.size).toBe(500);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.MetricDataQueries).toHaveLength(500);
+  });
+  it('revalidates historical intervals periodically instead of treating closed history as immutable', async () => {
+    await scan();
+    pointValue = (time) => (time.toISOString() === '2026-08-26T00:00:00.000Z' ? 10 : 1);
+    vi.setSystemTime(new Date('2026-09-15T12:01:00Z'));
+    const revised = await scan();
+    expect(revised.get('cpu')?.points.reduce((sum, point) => sum + point.value, 0)).toBe(23);
+    expect(requests).toHaveLength(2);
+  });
+
+  it('persists intervals through the established local SQLite cache across new scan contexts', async () => {
+    const cache = { store: undefined, directory: join(admissionDirectory, 'evidence') };
+    const first = await scan(endTime, query, cache);
+    expect(await scan(endTime, query, cache)).toEqual(first);
+    expect(requests).toHaveLength(1);
+  });
+});

--- a/packages/sdk/test/providers/aws-metric-planner.test.ts
+++ b/packages/sdk/test/providers/aws-metric-planner.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCloudWatchClient, withAwsClientCredentials } from '../../src/providers/aws/client.js';
+import {
+  emitAwsRequestTelemetry,
+  getAwsDiscoveryTimestamp,
+  getAwsExecutionSignal,
+  withAwsDiscoveryExecution,
+} from '../../src/providers/aws/execution.js';
+import { planCloudWatchSignals, withCloudWatchMetricPlanning } from '../../src/providers/aws/metric-planner.js';
+import type { CloudWatchMetricEvidence, CloudWatchMetricQuery } from '../../src/providers/aws/resources/cloudwatch.js';
+
+const query = (id: string, metricName = 'CPUUtilization'): CloudWatchMetricQuery => ({
+  id,
+  namespace: 'AWS/EC2',
+  metricName,
+  dimensions: [{ Name: 'InstanceId', Value: 'i-one' }],
+  period: 60,
+  stat: 'Average',
+});
+const window = (start: number, end: number) => ({
+  region: 'us-east-1',
+  startTime: new Date(start * 60_000),
+  endTime: new Date(end * 60_000),
+});
+type Request = Parameters<typeof planCloudWatchSignals>[0];
+const complete = (request: Request): Map<string, CloudWatchMetricEvidence> =>
+  new Map(
+    request.queries.map((metric) => [
+      metric.id,
+      {
+        status: 'Complete',
+        points: [0, 1, 2, 3].map((minute) => ({
+          timestamp: new Date(minute * 60_000).toISOString(),
+          value: minute + 1,
+        })),
+        window: {
+          startTime: request.startTime.toISOString(),
+          endTime: request.endTime.toISOString(),
+          periodSeconds: metric.period,
+        },
+        coverage: { expectedPoints: 4, observedPoints: 4 },
+        messages: [],
+        attempts: 1,
+      },
+    ]),
+  );
+
+describe('CloudWatch metric planning', () => {
+  it('does not replace a partial-period aggregate with a longer window aggregate', async () => {
+    const fetch = async (request: Request) => {
+      const response = complete(request);
+      for (const evidence of response.values()) {
+        evidence.points = [
+          { timestamp: request.startTime.toISOString(), value: (+request.endTime - +request.startTime) / 60_000 },
+        ];
+        evidence.coverage = { expectedPoints: 1, observedPoints: 1 };
+      }
+      return response;
+    };
+    const results = await withCloudWatchMetricPlanning(() =>
+      Promise.all([
+        planCloudWatchSignals({ ...window(0, 30), queries: [{ ...query('partial'), period: 3600 }] }, fetch),
+        planCloudWatchSignals({ ...window(0, 60), queries: [{ ...query('full'), period: 3600 }] }, fetch),
+      ]),
+    );
+    expect(results.map((result) => [...result.values()][0]?.points[0]?.value)).toEqual([30, 60]);
+  });
+
+  it('retains credentials, observation time and debug reporting in the owned execution', async () => {
+    const messages: string[] = [];
+    const credentials = { accessKeyId: 'planner-test-access', secretAccessKey: 'planner-test-secret' };
+    const result = await withAwsClientCredentials(credentials, () =>
+      withAwsDiscoveryExecution(
+        {
+          observationTimestamp: 123_000,
+          debugLogger: (message) => {
+            messages.push(message);
+          },
+        },
+        () =>
+          withCloudWatchMetricPlanning(() =>
+            planCloudWatchSignals({ ...window(0, 4), queries: [query('metric')] }, async (request) => {
+              const resolved = await createCloudWatchClient({ region: request.region }).config.credentials();
+              expect(resolved.accessKeyId).toBe('planner-test-access');
+              expect(getAwsDiscoveryTimestamp()).toBe(123_000);
+              emitAwsRequestTelemetry({ type: 'planner-test' });
+              return complete(request);
+            }),
+          ),
+      ),
+    );
+    expect(result.get('metric')?.status).toBe('Complete');
+    expect(messages).toContain('aws: attempt {"type":"planner-test"}');
+  });
+  it('passes unplanned requests directly to the transport', async () => {
+    const request = { ...window(0, 4), queries: [query('original')] };
+    const response = complete(request);
+    let received: Request | undefined;
+    expect(
+      await planCloudWatchSignals(request, async (options) => {
+        received = options;
+        return response;
+      }),
+    ).toBe(response);
+    expect(received).toBe(request);
+  });
+
+  it('splits a caller input larger than the admission bound into bounded requests', async () => {
+    const sizes: number[] = [];
+    const result = await withCloudWatchMetricPlanning(() =>
+      planCloudWatchSignals(
+        {
+          ...window(0, 4),
+          queries: Array.from({ length: 8193 }, (_, index) => query(`q${index}`, `Metric${index}`)),
+        },
+        async (request) => {
+          sizes.push(request.queries.length);
+          return complete(request);
+        },
+      ),
+    );
+    expect(sizes).toEqual([8192, 1]);
+    expect(result.size).toBe(8193);
+    expect(result.get('q8192')?.status).toBe('Complete');
+  });
+
+  it.each([
+    'PartialData',
+    'Forbidden',
+    'InternalError',
+    'Missing',
+    'Unknown',
+  ] as const)('preserves %s evidence and diagnostics for each caller interval', async (status) => {
+    const fetch = async (request: Request) => {
+      const response = complete(request);
+      for (const evidence of response.values()) {
+        evidence.status = status;
+        evidence.attempts = 3;
+        evidence.messages = [{ scope: 'query', code: 'EvidenceDiagnostic', value: 'retained' }];
+      }
+      return response;
+    };
+    const results = await withCloudWatchMetricPlanning(() =>
+      Promise.all([
+        planCloudWatchSignals({ ...window(0, 2), queries: [query('early')] }, fetch),
+        planCloudWatchSignals({ ...window(2, 4), queries: [query('late')] }, fetch),
+      ]),
+    );
+    expect(results.map((result) => [...result.values()][0])).toEqual([
+      expect.objectContaining({
+        status,
+        attempts: 3,
+        coverage: { expectedPoints: 2, observedPoints: 2 },
+        messages: [{ scope: 'query', code: 'EvidenceDiagnostic', value: 'retained' }],
+      }),
+      expect.objectContaining({
+        status,
+        attempts: 3,
+        coverage: { expectedPoints: 2, observedPoints: 2 },
+        messages: [{ scope: 'query', code: 'EvidenceDiagnostic', value: 'retained' }],
+      }),
+    ]);
+  });
+
+  it('cancels the physical execution once every inflight waiter cancels', async () => {
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const started = Promise.withResolvers<void>();
+    let transportSignal: AbortSignal | undefined;
+    const fetch = async (_request: Request): Promise<Map<string, CloudWatchMetricEvidence>> => {
+      transportSignal = getAwsExecutionSignal();
+      started.resolve();
+      return new Promise((_resolve, reject) =>
+        transportSignal?.addEventListener('abort', () => reject(transportSignal?.reason), { once: true }),
+      );
+    };
+    await withCloudWatchMetricPlanning(async () => {
+      const outcomes = Promise.allSettled([
+        withAwsDiscoveryExecution({ signal: firstController.signal }, () =>
+          planCloudWatchSignals({ ...window(0, 4), queries: [query('first')] }, fetch),
+        ),
+        withAwsDiscoveryExecution({ signal: secondController.signal }, () =>
+          planCloudWatchSignals({ ...window(0, 4), queries: [query('second')] }, fetch),
+        ),
+      ]);
+      await started.promise;
+      firstController.abort(new Error('first cancelled'));
+      expect(transportSignal?.aborted).toBe(false);
+      secondController.abort(new Error('second cancelled'));
+      expect((await outcomes).map((result) => result.status)).toEqual(['rejected', 'rejected']);
+      expect(transportSignal?.aborted).toBe(true);
+    });
+  });
+
+  it('removes cancelled queued metrics and does not fetch a cancelled interval bridging two windows', async () => {
+    const bridgeController = new AbortController();
+    const occupied = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const requests: Request[] = [];
+    const fetch = async (request: Request) => {
+      requests.push(request);
+      if (requests.length === 2) occupied.resolve();
+      await release.promise;
+      return complete(request);
+    };
+    await withCloudWatchMetricPlanning(async () => {
+      const blockers = [0, 10].map((minute) =>
+        planCloudWatchSignals({ ...window(minute, minute + 4), queries: [query(`block${minute}`)] }, fetch),
+      );
+      const sides = [20, 22].map((minute) =>
+        planCloudWatchSignals({ ...window(minute, minute + 1), queries: [query(`side${minute}`, 'NetworkIn')] }, fetch),
+      );
+      const bridge = withAwsDiscoveryExecution({ signal: bridgeController.signal }, () =>
+        planCloudWatchSignals(
+          { ...window(21, 22), queries: [query('bridge', 'NetworkIn'), query('unused', 'NetworkOut')] },
+          fetch,
+        ),
+      );
+      const rejected = expect(bridge).rejects.toThrow('remove bridge');
+      await occupied.promise;
+      bridgeController.abort(new Error('remove bridge'));
+      await rejected;
+      release.resolve();
+      await Promise.all([...blockers, ...sides]);
+      expect(
+        requests
+          .slice(2)
+          .map((request) => [
+            request.startTime.getTime(),
+            request.endTime.getTime(),
+            request.queries.map((metric) => metric.metricName),
+          ]),
+      ).toEqual([
+        [1_200_000, 1_260_000, ['NetworkIn']],
+        [1_320_000, 1_380_000, ['NetworkIn']],
+      ]);
+    });
+  });
+  it('rejects duplicate caller IDs before remapping or starting a transport', async () => {
+    let requests = 0;
+    await withCloudWatchMetricPlanning(async () => {
+      await expect(
+        planCloudWatchSignals(
+          { ...window(0, 4), queries: [query('duplicate'), query('duplicate', 'NetworkIn')] },
+          async (request) => {
+            requests += 1;
+            return complete(request);
+          },
+        ),
+      ).rejects.toThrow('Duplicate CloudWatch query ID');
+    });
+    expect(requests).toBe(0);
+  });
+
+  it('clears a cancelled pending request and its flush timer', async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      let requests = 0;
+      await withCloudWatchMetricPlanning(async () => {
+        const requested = Promise.withResolvers<void>();
+        const result = withAwsDiscoveryExecution({ signal: controller.signal }, () => {
+          const result = planCloudWatchSignals({ ...window(0, 4), queries: [query('cancelled')] }, async (request) => {
+            requests += 1;
+            return complete(request);
+          });
+          requested.resolve();
+          return result;
+        });
+        const rejected = expect(result).rejects.toThrow('cancel all');
+        await requested.promise;
+        controller.abort(new Error('cancel all'));
+        await rejected;
+        expect(vi.getTimerCount()).toBe(0);
+        expect(requests).toBe(0);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+  it('bounds active combined requests and waits for capacity beyond 8192 retained queries', async () => {
+    const release = Promise.withResolvers<void>();
+    let active = 0;
+    let maximumActive = 0;
+    const fetch = async (request: Request) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await release.promise;
+      active -= 1;
+      return complete(request);
+    };
+    await withCloudWatchMetricPlanning(async () => {
+      const requests = [0, 10, 20, 30, 40].map((minute) =>
+        planCloudWatchSignals({ ...window(minute, minute + 4), queries: [query(`m${minute}`)] }, fetch),
+      );
+      const overflow = expect(
+        planCloudWatchSignals(
+          { ...window(0, 4), queries: Array.from({ length: 8192 }, (_, index) => query(`overflow${index}`)) },
+          fetch,
+        ),
+      ).resolves.toHaveProperty('size', 8192);
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      release.resolve();
+      await Promise.all(requests);
+      await overflow;
+      expect(maximumActive).toBe(2);
+    });
+  });
+  it('keeps a shared request alive when its first waiter cancels', async () => {
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const started = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    let transportSignal: AbortSignal | undefined;
+    const fetch = async (request: Request) => {
+      transportSignal = getAwsExecutionSignal();
+      started.resolve();
+      await finish.promise;
+      transportSignal?.throwIfAborted();
+      return complete(request);
+    };
+    await withCloudWatchMetricPlanning(async () => {
+      const first = withAwsDiscoveryExecution({ signal: firstController.signal }, () =>
+        planCloudWatchSignals({ ...window(0, 4), queries: [query('first')] }, fetch),
+      );
+      const second = withAwsDiscoveryExecution({ signal: secondController.signal }, () =>
+        planCloudWatchSignals({ ...window(0, 4), queries: [query('second')] }, fetch),
+      );
+      const rejected = expect(first).rejects.toThrow('first stopped');
+      await started.promise;
+      firstController.abort(new Error('first stopped'));
+      await rejected;
+      expect(transportSignal?.aborted).toBe(false);
+      finish.resolve();
+      expect((await second).get('second')?.status).toBe('Complete');
+    });
+  });
+  it('joins adjacent cache misses without broadening other metrics and restores each interval', async () => {
+    const requests: Request[] = [];
+    const fetch = async (request: Request) => {
+      requests.push(request);
+      return complete(request);
+    };
+    const results = await withCloudWatchMetricPlanning(() =>
+      Promise.all([
+        planCloudWatchSignals({ ...window(0, 2), queries: [query('first')] }, fetch),
+        planCloudWatchSignals({ ...window(2, 4), queries: [query('second')] }, fetch),
+        planCloudWatchSignals({ ...window(0, 2), queries: [query('other', 'NetworkIn')] }, fetch),
+      ]),
+    );
+    expect(
+      requests.map((request) => [
+        request.startTime.getTime(),
+        request.endTime.getTime(),
+        request.queries.map((metric) => metric.metricName),
+      ]),
+    ).toEqual([
+      [0, 240_000, ['CPUUtilization']],
+      [0, 120_000, ['NetworkIn']],
+    ]);
+    expect(results[0]?.get('first')).toMatchObject({
+      status: 'Complete',
+      points: [
+        { timestamp: new Date(0).toISOString(), value: 1 },
+        { timestamp: new Date(60_000).toISOString(), value: 2 },
+      ],
+      window: { startTime: new Date(0).toISOString(), endTime: new Date(120_000).toISOString(), periodSeconds: 60 },
+      coverage: { expectedPoints: 2, observedPoints: 2 },
+    });
+    expect(results[1]?.get('second')?.points.map((point) => point.value)).toEqual([3, 4]);
+  });
+  it('shares one exact observation window across datasets with caller-owned query IDs', async () => {
+    const requests: Request[] = [];
+    const fetch = async (request: Request) => {
+      requests.push(request);
+      return complete(request);
+    };
+    const results = await withCloudWatchMetricPlanning(() =>
+      Promise.all([
+        planCloudWatchSignals({ ...window(0, 4), queries: [query('same')] }, fetch),
+        planCloudWatchSignals({ ...window(0, 4), queries: [query('same', 'NetworkIn')] }, fetch),
+      ]),
+    );
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.queries.map((metric) => metric.metricName)).toEqual(['CPUUtilization', 'NetworkIn']);
+    expect(new Set(requests[0]?.queries.map((metric) => metric.id)).size).toBe(2);
+    expect(results.map((result) => [...result.keys()])).toEqual([['same'], ['same']]);
+  });
+});


### PR DESCRIPTION
## Summary

- Reuse complete CloudWatch metric intervals after derived dataset evidence expires. Missing intervals and a bounded recent overlap are collected again, so late or revised data updates findings without refetching the entire lookback.
- Combine compatible pending metric requests across datasets, preserving exact observation windows, per-series status, sample-weighted aggregates, pagination, quotas, and independent waiter cancellation.
- Consume the merged evidence cache contract unchanged. Prerequisite PRs #251 (#231), #246 (#228), and #239/#249 (#226) are merged and verified as ancestors of this branch.

## Diagram

```mermaid
flowchart LR
  D[Selected dataset metrics] --> C[Scoped interval cache]
  C -->|Fresh complete intervals| E[Exact-window evidence]
  C -->|Missing or expired intervals| P[Bounded shared planner]
  P --> Q[Existing AWS request and datapoint admission]
  Q --> W[CloudWatch pagination and retries]
  W --> C
  E --> R[Rule evaluation]
```

## Scope

- [ ] `cloudburn` (cli)
- [x] `@cloudburn/sdk`
- [ ] `@cloudburn/rules`
- [x] docs/community files

The shared CloudWatch path affects live metric collection across datasets, so this carries `impact:significant`. The generic cache/store interfaces, authorization identity, provenance schema, and public SDK exports remain unchanged. Coordination with #233 reserves metric internals here and orchestration/progress there; shared documentation sections are separate. The only new execution helper retains the existing diagnostic logger for independently owned requests.

## Release Notes

- [x] Added a `.changeset/*.md` file for published package changes
- [ ] No published package changes in this PR

Recent intervals use a 5-minute TTL within a 3-day overlap; older history is revalidated after 7 days. Existing cache refresh/off modes and storage limits apply. Larger fleets need enough `maxEntries`/`maxBytes` for interval evidence. Rolling windows with different aggregation phases cannot share intervals; changed edges can require a separate narrow request. Partial-period aggregates only coalesce for identical windows.

## Verification

All gates below passed through `pnpm verify`, using Node v24.18.0 and pnpm 11.15.1 in this isolated worktree. Focused metric, planner, and HTTP integration tests were also run during red-green development. No live AWS calls were made.

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm verify`

The final gate completed 14 tasks successfully, including 1,061 SDK tests, CLI end-to-end checks, and installed-package tests. Simplifier and correctness reviews are complete.

Synthetic HTTP evidence: 2 ALBs over 14 days require 1 request/28 datapoints cold, no extra metric request for the repeated window, and 1 request/6 datapoints on daily rollover. That is 78.6% fewer rollover datapoints than the full-window baseline. A late activity revision changes the finding, and final providers, evaluations, and diagnostics equal uncached collection. Additional tests cover weighted Lambda duration, historical revalidation, SQLite reuse, identity separation, 500-query packing, queue bounds, partial-period compatibility, and cancellation while another scan still needs shared work.

## Boundary Checks

- [x] No engine/parser/provider logic added to `@cloudburn/rules`
- [x] CLI delegates scan logic to SDK
- [x] README/CONTRIBUTING/docs updated when behavior changed

## Related Issues

Closes #232. Part of #235. Coordinated with #233; this PR does not depend on its unmerged implementation.
