### PR TITLE
feat(sdk): pipeline discovery and report provisional results

### DIFF
--- a/.changeset/quick-rivers-discover.md
+++ b/.changeset/quick-rivers-discover.md
@@ -1,0 +1,5 @@
+---
+'@cloudburn/sdk': minor
+---
+
+Pipeline independent account collection and complete catalog scopes, and report provisional evaluated rule findings through discovery progress. Preserve final precedence, partial-region evidence, and cancellation semantics while reusing the established evidence cache.

--- a/.changeset/quiet-owls-report.md
+++ b/.changeset/quiet-owls-report.md
@@ -1,0 +1,5 @@
+---
+'cloudburn': minor
+---
+
+Show provisional rule results as discovery rules finish on interactive terminals. Progress goes to stderr; the final report and exit code remain authoritative, and JSON output stays a single final result on stdout.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -82,6 +82,12 @@ actual CloudWatch request windows with cache provenance and verify dependency-ve
 suite uses real child processes for concurrent refresh, owner crashes, lease expiry, and old-writer fencing, plus
 synthetic loaders for corruption, invalidation, bounded eviction, and value isolation. No AWS access is needed.
 
+Pipeline tests gate synthetic catalog pages and hydration responses through `CloudBurnClient.discover()`.
+They assert that account evidence starts during catalog preparation, a cached catalog type releases before an unrelated
+miss, and useful provisional results precede final completion. Empty pages with continuation tokens cannot produce a
+pass. Cancellation after progress stops transport and later events and rejects the final result. Engine integration
+coverage retains selected optional evidence, finding precedence, and partial-region evaluation semantics.
+
 ### `cloudburn` (CLI)
 
 Command tests (`*.command.test.ts`) mock the SDK boundary to isolate CLI behavior. Their output assertions also cover

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -64,7 +64,7 @@ All stdout-producing commands return a typed `CliResponse` and share the same fo
 - `rules list`, `config`, and `estimate` all use the shared formatter system instead of ad hoc string output.
 - `completion` is a structural parent command. `completion bash|fish|zsh` prints shell completion scripts for the selected shell.
 - `--debug` is a global flag that relays SDK and provider execution tracing to `stderr` without changing normal command output on `stdout`.
-- `discover` streams progress lines (catalog ready, datasets completed) to `stderr` while it runs, but only when `stderr` is an interactive terminal and `--debug` is off; piped and scripted invocations keep a quiet `stderr`, and `stdout` stays machine-parseable either way.
+- `discover` streams catalog, dataset, and provisional rule progress to `stderr` when `stderr` is an interactive terminal and `--debug` is off. Rule lines show completed/total rules, the rule ID, status, and finding count, explicitly marked provisional. They can arrive before all datasets finish; the final report and exit code remain authoritative. Piped and scripted invocations keep a quiet `stderr`, and `--format json` writes one final JSON result to `stdout`.
 - `--format` is documented as a global option and defaults to `table`, except `config --print` and `config --print-template`, which preserve raw YAML by default for redirection workflows.
 - `scan` and `discover` can also source their default format from `.cloudburn.yml`; explicit `--format` still wins.
 - The hidden `__complete` command exists only as the runtime hook for generated shell scripts.

--- a/docs/architecture/sdk.md
+++ b/docs/architecture/sdk.md
@@ -43,8 +43,13 @@ graph TD
     LR[buildRuleRegistry] --> LD[collect discoveryDependencies]
     LD --> LRg[resolve dataset registry entries]
     LRg --> LC[buildAwsDiscoveryCatalog]
-    LC --> LL[load required datasets]
-    LL --> LX[build LiveEvaluationContext]
+    LRg --> AL[load independent account datasets]
+    LC -->|complete type scope| LL[load dependency-ready datasets]
+    AL --> RP[optional provisional rule evaluation]
+    LL --> RP
+    LC --> LX[build final LiveEvaluationContext]
+    AL --> LX
+    LL --> LX
     LX --> LE["rule.evaluateLive() => Finding | null"]
     LE --> LA{includeEvaluationResources?}
     LA -->|yes| LP[project normalized resources and rule status]
@@ -81,11 +86,16 @@ Static rule evaluation retains those scopes, including joins between datasets su
 2. Collect unique `discoveryDependencies` from active discovery rules.
 3. Expand declarative dependencies and catalog queries through the AWS discovery dataset registry.
 4. Union required Resource Explorer `resourceTypes` from the resolved dataset definitions.
-5. Build one AWS discovery catalog through Resource Explorer filter-only list queries.
-6. Load only the required datasets, reusing fresh versioned evidence when explicitly configured. Cache keys include
-   authorization scope, selected catalog membership/view, observation interval, and dependency fingerprints.
-7. Build `LiveEvaluationContext` with `{ catalog, resources: LiveResourceBag }`.
-8. Invoke each live evaluator.
+5. Prepare one AWS discovery catalog through Resource Explorer filter-only list queries alongside independent
+   account-scoped collection. Keep packed queries and release each resource type only after its complete selected scope
+   finishes pagination; cached scopes can release before unrelated misses.
+6. Load only required datasets after their declared catalog inputs and dependencies settle, reusing fresh versioned
+   evidence when explicitly configured. Cache keys retain authorization scope, observation interval, and dependency
+   fingerprints. Catalog-backed keys retain selected membership/view; account-only keys omit unrelated catalog metadata.
+7. Optionally evaluate dependency-ready rules for provisional progress, waiting for selected optional evidence too.
+   Catalog scope tracking is bounded by the selected registry types; existing regional workers and request limits apply.
+8. Build the final `LiveEvaluationContext` with `{ catalog, resources: LiveResourceBag }` and invoke live evaluators
+   against that completed context, then apply finding precedence. Progress never replaces final evaluation.
 9. When requested, resolve each rule's evaluated resource projection through the SDK-owned AWS evaluation registry.
 10. Group non-null rule findings under `providers -> rules -> findings` and attach evaluation evidence to `evaluations`.
 
@@ -125,7 +135,10 @@ Current live-discovery behavior:
 - Wrapped service calls use one AWS SDK attempt per outer attempt, with at most six physical attempts by default. The request module owns admission, shared retry allowance, throttling feedback, and recovery. Catalog and control-plane requests use that same retry owner, including setup mutations and polls.
 - One public-operation budget spans catalog construction and all dataset loads. Catalog, status, initialization, supported types, and collectors share account quota state across operations and independent processes using the same local admission directory. Limits follow the service's operation groups and applicable region; Route 53 keeps its global five-per-second budget, and CloudWatch metric calls also reserve datapoint throughput. Credential and cache isolation remain per run. [AWS request scheduling](../reference/aws-request-scheduling.md) owns policies, overrides, telemetry, crash recovery, and the boundary for calls outside the budget.
 - `mapWithConcurrency` preserves input order and starts the next item whenever a worker is free. The first mapper failure stops that pool's queued work and rejects immediately with the original reason. Active mapper calls keep running and their late rejections remain observed. Discovery cancellation reaches the pool through mapper rejection. Resource-level errors deliberately caught and returned as diagnostics allow mapping to continue.
-- `CloudBurnClient.discover({ onProgress })` streams `AwsDiscoveryProgressEvent` values (catalog ready, per-dataset completion counts) while the run executes, so callers can render live feedback without waiting for the final result.
+- `CloudBurnClient.discover({ onProgress })` streams catalog readiness, per-dataset completion counts, and provisional
+  evaluated rule results. Required and selected optional evidence must settle first. Events follow completion order;
+  only the final resolved scan is authoritative. [Progress semantics](../reference/finding-shape.md#awsdiscoveryprogressevent)
+  cover precedence, incomplete evidence, cancellation, and separate first-result/final-completion timing.
 - Resource Explorer catalog failures degrade when the run also requested account-scoped datasets: the SDK records one catalog diagnostic, marks every catalog-backed dataset unavailable (skipping the rules that need them), and still evaluates account-scoped datasets. When every requested dataset needs the catalog, the failure stays fatal so the actionable Resource Explorer error reaches the user.
 - CloudWatch metric requests group matching periods and batch up to 500 queries or 100,800 estimated datapoints. Observation windows are chosen independently of aggregation periods. Two batches can run concurrently within the shared service budget; pagination retains each batch’s fixed window and incomplete series retain their evidence status. See the [GetMetricData API limits](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html).
 - SageMaker endpoint, NAT gateway, and VPC endpoint collectors use a [bounded resource metric stage](../../packages/sdk/src/providers/aws/resources/resource-metrics.ts). Metadata hydration has 10 endpoint workers or 2 network describe-batch workers per region. Queries accumulate across metadata completions, with at most 500 queries or 100,800 estimated datapoints per flush. One flush runs at a time and backpressures producers; the last partial batch flushes when metadata production ends. Pending work is bounded by that metric batch plus the active metadata workers. SageMaker config lookups remain deduplicated per region, and resource summaries consume and release each completed batch’s evidence. Input catalogs, normalized outputs, and the config lookup cache still scale with inventory size.

--- a/docs/reference/finding-shape.md
+++ b/docs/reference/finding-shape.md
@@ -90,6 +90,30 @@ type ProviderFindingGroup = {
 
 This is the provider-level group returned by the SDK scan engines.
 
+## AwsDiscoveryProgressEvent
+
+`CloudBurnClient.discover({ onProgress })` accepts a synchronous callback. Its discriminated union now includes
+`kind: 'rule'` alongside the existing `catalog` and `dataset` events. Consumers that switch exhaustively over `kind`
+should handle this additive variant.
+
+| Kind | Fields | Meaning |
+| ---- | ------ | ------- |
+| `catalog` | `resourceCount`, `searchRegion` | The entire requested catalog finished. |
+| `dataset` | `datasetKey`, `completedDatasets`, `totalDatasets` | One requested dataset settled, including unavailable evidence. This is not a pass result. |
+| `rule` | `ruleId`, `status`, `findingCount`, `findings`, `reason?`, `provisional: true`, `completedRules`, `totalRules`, `elapsedMs` | Required and selected optional evidence settled and the rule was evaluated. |
+
+Rule `status` uses the same `triggered | passed | unknown | not_applicable` values as `RuleEvaluation`.
+`findings` contains normalized `FindingMatch[]` before cross-rule precedence, and `findingCount` is its length.
+Unavailable required datasets produce `not_applicable`; incomplete resource or regional coverage cannot become a
+full pass. `elapsedMs` starts after rule selection and excludes public-call configuration and identity setup.
+
+Rule events are optional, emitted at most once per selected rule, and ordered by evidence completion. They can precede
+`catalog`. Counts report settled work, including skipped rules. All events are provisional feedback for an in-progress
+scan: precedence or a later catalog failure can change the final output. The SDK re-evaluates the completed context
+and applies precedence before resolving `ScanResult`, preserving deterministic final providers, rules, and findings.
+The resolved promise is the final signal; there is no final-progress event. On cancellation, discard the provisional
+state because the promise rejects without a successful partial result. Callback errors also reject discovery.
+
 ## `ScanResult`
 
 ```ts

--- a/packages/cloudburn/README.md
+++ b/packages/cloudburn/README.md
@@ -158,6 +158,10 @@ access, or incomplete configurations produce diagnostics. The SDK exposes both t
 `includeEvaluationResources: true`; the CLI prints finding identities and diagnostics.
 `CLDBRN-AWS-SAGEMAKER-3` uses Cost Explorer coverage data and remains available when Cost Optimization Hub is unavailable.
 Use `--debug` to print SDK and provider execution tracing to `stderr` without changing the normal `stdout` format.
+On interactive terminals, discovery prints catalog and dataset progress plus provisional rule results to `stderr` as
+rules finish. Each rule line includes its ID, status, and finding count. Provisional results describe work completed so
+far; the final report and exit code are authoritative. Progress is silent when `stderr` is not a terminal or `--debug`
+is enabled. `--format json` writes one final JSON result to `stdout`.
 
 ## Shell Completion
 

--- a/packages/cloudburn/src/progress.ts
+++ b/packages/cloudburn/src/progress.ts
@@ -20,6 +20,13 @@ export const resolveCliDiscoveryProgressLogger = (
   }
 
   return (event: AwsDiscoveryProgressEvent) => {
+    if (event.kind === 'rule') {
+      process.stderr.write(
+        `discover: rules ${event.completedRules}/${event.totalRules} (${event.ruleId}: ${event.status}, findings: ${event.findingCount}, provisional)\n`,
+      );
+      return;
+    }
+
     process.stderr.write(
       event.kind === 'catalog'
         ? `discover: catalog ready with ${event.resourceCount} resources from ${event.searchRegion}\n`

--- a/packages/cloudburn/test/discover.command.test.ts
+++ b/packages/cloudburn/test/discover.command.test.ts
@@ -358,6 +358,45 @@ describe('discover command', () => {
     expect(process.exitCode).toBe(0);
   });
 
+  it('reports provisional rule results on stderr before writing one final JSON result', async () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    let progressBeforeCompletion = '';
+    let stdoutCallsBeforeCompletion = 0;
+    vi.spyOn(CloudBurnClient.prototype, 'discover').mockImplementation(
+      async (options?: { onProgress?: (event: unknown) => void }) => {
+        options?.onProgress?.({
+          kind: 'rule',
+          ruleId: 'CLDBRN-AWS-EBS-1',
+          provisional: true,
+          status: 'triggered',
+          findingCount: 1,
+          findings: [{ resourceId: 'vol-123', region: 'us-east-1' }],
+          completedRules: 1,
+          totalRules: 2,
+          elapsedMs: 40,
+        });
+
+        progressBeforeCompletion = stderr.mock.calls.map(([chunk]) => String(chunk)).join('');
+        stdoutCallsBeforeCompletion = stdout.mock.calls.length;
+
+        return liveScanResult;
+      },
+    );
+
+    await withStderrTty(true, async () => {
+      await createProgram().parseAsync(['discover', '--format', 'json', '--exit-code'], { from: 'user' });
+    });
+
+    expect(progressBeforeCompletion).toContain(
+      'discover: rules 1/2 (CLDBRN-AWS-EBS-1: triggered, findings: 1, provisional)',
+    );
+    expect(stdoutCallsBeforeCompletion).toBe(0);
+    expect(stdout).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(stdout.mock.calls[0]?.[0]))).toEqual(liveScanResult);
+    expect(process.exitCode).toBe(1);
+  });
+
   it('keeps stderr quiet when discover output is not attached to a terminal', async () => {
     const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -28,7 +28,7 @@ The [package README](README.md) owns public SDK usage and AWS permissions; the
   enrichment or rule-specific resource parsing to interpret a discovery result.
 - SDK owns `.cloudburn.yml` / `.cloudburn.yaml` loading, upward config discovery, mode-specific config validation, and rule registry filtering for `iac` and `discovery`.
 - Static IaC scanning is dataset-driven. Parse only the source kinds required by active `staticDependencies`, then load the requested datasets into `StaticResourceBag`.
-- Live AWS discovery is Resource Explorer first and dataset-driven. Build one catalog, then load only the datasets required by active rules.
+- Live AWS discovery is Resource Explorer first and dataset-driven. Prepare one catalog alongside independent account collection; load required datasets only after their declared catalog inputs are complete.
 - Rules declare dataset keys through `staticDependencies`, `discoveryDependencies`, and optional supporting evidence in
   `optionalDiscoveryDependencies`. SDK owns dataset-to-resource-type mapping and dataset loader wiring.
 - Keep mode and service filtering in registry selection so excluded rules cannot trigger dataset loading.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -57,7 +57,7 @@ without rerunning the scan. SDK policy evaluation reports state; it does not cha
 
 ### Live discovery
 
-Use `initializeDiscovery()` first to set up AWS Resource Explorer. CloudBurn uses it as the live service catalog before it runs discovery rules.
+Use `initializeDiscovery()` first to set up AWS Resource Explorer. CloudBurn uses it to select catalog-backed resources; independent account collection can run alongside catalog preparation.
 
 ```ts
 import { CloudBurnClient } from '@cloudburn/sdk';
@@ -95,6 +95,38 @@ const result = await client.discover({
 ```
 
 An expired deadline rejects with `TimeoutError`; cancellation rejects with the signal's reason. Both stop work owned exclusively by that caller without returning partial results. A shared evidence refresh continues while another caller still needs it. Cancellation during initialization stops further setup work; mutations already accepted by AWS remain in place and a later initialization observes that state. AWS clients and lookup caches belong to their managed execution and are released when it ends.
+
+#### Discovery progress
+
+Pass `onProgress` to receive catalog, dataset, and provisional rule events while discovery runs:
+
+```typescript
+const startedAt = performance.now();
+let firstResultMs: number | undefined;
+const result = await client.discover({
+  onProgress(event) {
+    if (event.kind !== 'rule') return;
+    firstResultMs ??= performance.now() - startedAt;
+    console.error(`${event.ruleId}: ${event.status}, ${event.findingCount} findings (provisional)`);
+  },
+});
+console.error({ firstResultMs, totalMs: performance.now() - startedAt });
+```
+
+A rule event includes normalized `findings`, `status`, an optional `reason`, completion counts, and `elapsedMs` since
+rule selection. Events arrive in completion order. Every rule event has `provisional: true`: another rule may supersede
+its findings, or a later catalog failure may invalidate its scope. Replace progress state with the resolved `ScanResult`;
+never persist provisional events as final scan results. Cancellation rejects even when events were already delivered.
+
+Required evidence and any optional evidence selected by the scan must finish before a rule event. Optional dependencies
+alone do not trigger extra collection. Empty catalog pages with continuation tokens never release a rule. A resource
+type becomes ready only after all its selected-region queries finish pagination; a shared packed query releases its
+types together. Cached types can become ready while unrelated cache misses are still loading.
+
+Debug logging reports `sdk: live scan timing` with `firstRuleMs` and `totalMs`, measured from rule selection.
+`firstRuleMs` is `null` when no provisional evaluation was requested or emitted. The example above measures the entire
+public call, including setup, so its values can differ. See the [progress reference](../../docs/reference/finding-shape.md#awsdiscoveryprogressevent)
+for the event fields and compatibility notes.
 
 #### Reusable evidence
 

--- a/packages/sdk/src/engine/run-live.ts
+++ b/packages/sdk/src/engine/run-live.ts
@@ -1,4 +1,4 @@
-import { type DiscoveryDatasetMap, LiveResourceBag } from '@cloudburn/rules';
+import { type DiscoveryDatasetMap, LiveResourceBag, type Rule } from '@cloudburn/rules';
 import { toBuiltInRuleMetadata } from '../built-in-rules.js';
 import { emitDebugLog } from '../debug.js';
 import { discoverAwsResources } from '../providers/aws/discovery.js';
@@ -14,6 +14,13 @@ const toRuleEvaluationMetadata = (rule: Parameters<typeof toBuiltInRuleMetadata>
   return metadata;
 };
 
+/**
+ * Collects selected live evidence and evaluates rules, optionally reporting provisional results.
+ * @param config - Effective rule selection and discovery configuration.
+ * @param target - AWS catalog and account collection scope.
+ * @param options - Debug logging, optional evaluation projection, and provisional progress callback.
+ * @returns Authoritative results after all evidence and finding precedence are resolved.
+ */
 export const runLiveScan = async (
   config: CloudBurnConfig,
   target: AwsDiscoveryTarget,
@@ -25,15 +32,58 @@ export const runLiveScan = async (
 ): Promise<ScanResult> => {
   const registry = buildRuleRegistry(config, 'discovery');
   emitDebugLog(options?.debugLogger, `sdk: resolved ${registry.activeRules.length} active discovery rules`);
-  const {
-    diagnostics = [],
-    unavailableDatasets = new Map(),
-    unavailableRegions = new Map(),
-    ...liveContext
-  } = await discoverAwsResources(registry.activeRules, target, {
+  const startedAtMs = Date.now();
+  let completedRules = 0;
+  let firstRuleMs: number | undefined;
+  const context = await discoverAwsResources(registry.activeRules, target, {
     debugLogger: options?.debugLogger,
     onProgress: options?.onProgress,
+    ...(options?.onProgress
+      ? {
+          onRuleReady: (rule: Rule, context: Awaited<ReturnType<typeof discoverAwsResources>>) => {
+            const result = evaluateLiveRules([rule], context, { includeEvaluationStatus: true });
+            const evaluation = result.evaluations?.rules[0];
+            if (!evaluation) return;
+            completedRules += 1;
+            const elapsedMs = Date.now() - startedAtMs;
+            firstRuleMs ??= elapsedMs;
+            options.onProgress?.({
+              kind: 'rule',
+              ruleId: rule.id,
+              provisional: true,
+              status: evaluation.status,
+              findingCount: evaluation.findingCount,
+              findings: result.providers.flatMap((provider) => provider.rules.flatMap((finding) => finding.findings)),
+              ...(evaluation.reason ? { reason: evaluation.reason } : {}),
+              completedRules,
+              totalRules: registry.activeRules.length,
+              elapsedMs,
+            });
+          },
+        }
+      : {}),
   });
+  const result = evaluateLiveRules(registry.activeRules, context, options);
+  emitDebugLog(
+    options?.debugLogger,
+    `sdk: live scan timing ${JSON.stringify({ firstRuleMs: firstRuleMs ?? null, totalMs: Date.now() - startedAtMs })}`,
+  );
+  return {
+    ...result,
+    ...(getAwsEvidenceProvenance() ? { evidence: getAwsEvidenceProvenance() } : {}),
+  };
+};
+
+// The same evaluation path handles provisional snapshots and the authoritative final context.
+// Re-evaluate at completion so a later catalog failure or precedence winner cannot leave stale output.
+const evaluateLiveRules = (
+  rules: Rule[],
+  context: Awaited<ReturnType<typeof discoverAwsResources>>,
+  options?: { includeEvaluationResources?: boolean; includeEvaluationStatus?: boolean },
+): ScanResult => {
+  const includeEvaluationResources = options?.includeEvaluationResources;
+  const includeEvaluations = includeEvaluationResources || options?.includeEvaluationStatus;
+  const { diagnostics = [], unavailableDatasets = new Map(), unavailableRegions = new Map(), ...liveContext } = context;
   const unresolvedUnavailableDatasets: unknown = unavailableDatasets;
   const unavailableDatasetDiagnostics =
     unresolvedUnavailableDatasets instanceof Map
@@ -46,7 +96,7 @@ export const runLiveScan = async (
   const scanDiagnostics = [...diagnostics];
   const evaluationRules: NonNullable<ScanResult['evaluations']>['rules'] = [];
   const evaluationResourceSets = new Map<string, NonNullable<ScanResult['evaluations']>['resourceSets'][number]>();
-  const evaluatedRules = registry.activeRules.map((rule): EvaluatedRuleFinding => {
+  const evaluatedRules = rules.map((rule): EvaluatedRuleFinding => {
     if (!rule.supports.includes('discovery') || !rule.evaluateLive) {
       return {
         provider: rule.provider,
@@ -76,7 +126,7 @@ export const runLiveScan = async (
         status: 'skipped' as const,
       };
       scanDiagnostics.push(skippedRuleDiagnostic);
-      if (options?.includeEvaluationResources) {
+      if (includeEvaluations) {
         evaluationRules.push({
           ...toRuleEvaluationMetadata(rule),
           findingCount: 0,
@@ -164,18 +214,22 @@ export const runLiveScan = async (
       });
     }
 
-    if (options?.includeEvaluationResources) {
-      const evaluationResourceSet = getAwsRuleEvaluationResourceSet(rule, ruleContext.resources);
-      if (excludedRegions.size > 0) evaluationResourceSet.id += `:excluding:${[...excludedRegions].sort().join(',')}`;
-      if (!evaluationResourceSets.has(evaluationResourceSet.id)) {
-        evaluationResourceSets.set(evaluationResourceSet.id, evaluationResourceSet);
+    if (includeEvaluations) {
+      const evaluationResourceSet = includeEvaluationResources
+        ? getAwsRuleEvaluationResourceSet(rule, ruleContext.resources)
+        : undefined;
+      if (evaluationResourceSet) {
+        if (excludedRegions.size > 0) evaluationResourceSet.id += `:excluding:${[...excludedRegions].sort().join(',')}`;
+        if (!evaluationResourceSets.has(evaluationResourceSet.id)) {
+          evaluationResourceSets.set(evaluationResourceSet.id, evaluationResourceSet);
+        }
       }
       evaluationRules.push({
         ...toRuleEvaluationMetadata(rule),
         ...(coverage ? { coverage } : {}),
         ...(coverageReason ? { reason: coverageReason } : {}),
         findingCount: finding?.findings.length ?? 0,
-        resourceSetId: evaluationResourceSet.id,
+        ...(evaluationResourceSet ? { resourceSetId: evaluationResourceSet.id } : {}),
         ruleId: rule.id,
         source: 'discovery',
         status: finding ? 'triggered' : coverageReason ? 'unknown' : 'passed',
@@ -193,9 +247,8 @@ export const runLiveScan = async (
   const findings = groupFindingsByProvider(consolidatedRules);
 
   return {
-    ...(getAwsEvidenceProvenance() ? { evidence: getAwsEvidenceProvenance() } : {}),
     ...(scanDiagnostics.length > 0 ? { diagnostics: scanDiagnostics } : {}),
-    ...(options?.includeEvaluationResources
+    ...(includeEvaluations
       ? { evaluations: { resourceSets: [...evaluationResourceSets.values()], rules: evaluationRules } }
       : {}),
     providers: findings,

--- a/packages/sdk/src/providers/aws/discovery.ts
+++ b/packages/sdk/src/providers/aws/discovery.ts
@@ -335,6 +335,7 @@ const buildEmptyLocalCatalog = async (searchRegion: string): Promise<AwsDiscover
  *
  * @param rules - Active rules that declare their discovery dataset requirements.
  * @param target - Discovery target controlling current-region, explicit-region, or all-region behavior.
+ * @param options - Logging and callbacks for settled datasets and dependency-ready rule snapshots.
  * @returns Hydrated live evaluation context.
  */
 export const discoverAwsResources = async (
@@ -343,6 +344,7 @@ export const discoverAwsResources = async (
   options?: {
     debugLogger?: (message: string) => void;
     onProgress?: (event: AwsDiscoveryProgressEvent) => void;
+    onRuleReady?: (rule: Rule, context: LiveDiscoveryContext) => void;
   },
 ): Promise<LiveDiscoveryContext> => {
   const datasetKeys = collectDiscoveryDependencies(rules);
@@ -375,58 +377,107 @@ export const discoverAwsResources = async (
     options?.debugLogger,
     `aws: resolved Resource Explorer resource types ${resourceTypes.length === 0 ? 'none' : resourceTypes.join(', ')}`,
   );
-  let catalog: AwsDiscoveryCatalog;
+  const datasetRegion = await resolveAccountScopedDatasetRegion(target);
+  const accountCatalog = await buildEmptyLocalCatalog(datasetRegion);
+  let catalog = accountCatalog;
+  const catalogInputs = new Map(
+    resourceTypes.map((type) => {
+      let resolve!: (catalog: AwsDiscoveryCatalog) => void;
+      const promise = new Promise<AwsDiscoveryCatalog>((fulfill) => {
+        resolve = fulfill;
+      });
+      return [type, { promise, resolve }] as const;
+    }),
+  );
+  const readyCatalogs = new Map<string, AwsDiscoveryCatalog>();
+  let catalogScopePromise: Promise<Awaited<ReturnType<typeof getAwsResourceExplorerEvidenceScope>>> | undefined;
+  const resolveCatalogScope = () => (catalogScopePromise ??= getAwsResourceExplorerEvidenceScope(target));
   let catalogFailureDiagnostic: ScanDiagnostic | undefined;
 
-  if (resourceTypes.length === 0) {
-    catalog = await buildEmptyLocalCatalog(await resolveAccountScopedDatasetRegion(target));
-  } else {
-    try {
-      catalog =
-        options?.debugLogger === undefined
-          ? await buildAwsDiscoveryCatalog(target, resourceTypes)
-          : await buildAwsDiscoveryCatalog(target, resourceTypes, { debugLogger: options.debugLogger });
-    } catch (err) {
-      throwIfAwsExecutionAborted();
-      const hasAccountScopedDatasets = datasetDefinitions.some((definition) => definition.resourceTypes.length === 0);
+  const catalogReady = (async () => {
+    if (resourceTypes.length > 0) {
+      try {
+        catalog = await buildAwsDiscoveryCatalog(target, resourceTypes, {
+          debugLogger: options?.debugLogger,
+          onResourceTypeReady: (resourceType, readyCatalog) => {
+            throwIfAwsExecutionAborted();
+            readyCatalogs.set(resourceType, readyCatalog);
+            catalogInputs.get(resourceType)?.resolve(readyCatalog);
+          },
+        });
+      } catch (err) {
+        throwIfAwsExecutionAborted();
+        const hasAccountScopedDatasets = datasetDefinitions.some((definition) => definition.resourceTypes.length === 0);
 
-      // With no account-scoped datasets in the run, nothing can load without
-      // the catalog, so the failure stays fatal and keeps its actionable error.
-      if (!hasAccountScopedDatasets) {
-        throw err;
+        // Without account-scoped evidence, catalog errors remain fatal even if
+        // a completed type already produced provisional feedback.
+        if (!hasAccountScopedDatasets) {
+          throw err;
+        }
+
+        emitDebugLog(
+          options?.debugLogger,
+          `aws: catalog build failed, degrading to account-scoped datasets: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        catalogFailureDiagnostic = buildCatalogFailureDiagnostic(err);
+        catalog = accountCatalog;
       }
-
-      emitDebugLog(
-        options?.debugLogger,
-        `aws: catalog build failed, degrading to account-scoped datasets: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      catalogFailureDiagnostic = buildCatalogFailureDiagnostic(err);
-      catalog = await buildEmptyLocalCatalog(await resolveAccountScopedDatasetRegion(target));
     }
-  }
-  emitDebugLog(
-    options?.debugLogger,
-    `aws: catalog ready with ${catalog.resources.length} resources from ${catalog.searchRegion}`,
-  );
+    emitDebugLog(
+      options?.debugLogger,
+      `aws: catalog ready with ${catalog.resources.length} resources from ${catalog.searchRegion}`,
+    );
 
-  if (resourceTypes.length > 0 && !catalogFailureDiagnostic) {
-    options?.onProgress?.({
-      kind: 'catalog',
-      resourceCount: catalog.resources.length,
-      searchRegion: catalog.searchRegion,
+    if (resourceTypes.length > 0 && !catalogFailureDiagnostic) {
+      options?.onProgress?.({
+        kind: 'catalog',
+        resourceCount: catalog.resources.length,
+        searchRegion: catalog.searchRegion,
+      });
+    }
+  })();
+  // Observe catalog failure immediately while independent collection starts.
+  void catalogReady.catch(() => undefined);
+  // Share each completed selection across datasets and regional workers instead of
+  // rebuilding and retaining a full catalog copy for every regional load.
+  const catalogSelections = new Map<
+    string,
+    Promise<{ catalog: AwsDiscoveryCatalog; resources: AwsDiscoveredResource[] }>
+  >();
+  const resolveDatasetCatalog = (types: string[]) => {
+    const key = JSON.stringify(types);
+    const existing = catalogSelections.get(key);
+    if (existing) return existing;
+    const selection = Promise.all(
+      types.map((type) =>
+        Promise.race([
+          catalogInputs.get(type)?.promise ?? catalogReady.then(() => catalog),
+          catalogReady.then(() => catalog),
+        ]),
+      ),
+    ).then((inputs) => {
+      const resourcesByType = buildResourcesByTypeIndex(inputs.flatMap((input) => input.resources));
+      const resources = [
+        ...new Map(
+          types.flatMap((type) => resourcesByType.get(type) ?? []).map((resource) => [resource.arn, resource]),
+        ).values(),
+      ];
+      return {
+        catalog: {
+          ...(inputs[0] ?? accountCatalog),
+          resources: [...resources].sort((left, right) => left.arn.localeCompare(right.arn)),
+        },
+        resources,
+      };
     });
-  }
-  const resourcesByType = buildResourcesByTypeIndex(catalog.resources);
-  const catalogScope =
-    isAwsEvidenceCacheEnabled() && resourceTypes.length > 0 && !catalogFailureDiagnostic
-      ? await getAwsResourceExplorerEvidenceScope(target)
-      : undefined;
+    catalogSelections.set(key, selection);
+    return selection;
+  };
   const datasetLoadPromises = new Map<string, Promise<AwsDiscoveryDatasetLoad>>();
   const loadedDatasetKeys = new Set<DiscoveryDatasetKey>();
   const unavailableRegions = new Map<DiscoveryDatasetKey, Set<string>>();
   let accountIdPromise: Promise<string> | undefined;
-  const resolveAccountId = (): Promise<string> => (accountIdPromise ??= resolveAwsAccountId(catalog.searchRegion));
-  const datasetRegion = await resolveAccountScopedDatasetRegion(target);
+  const resolveAccountId = (): Promise<string> => (accountIdPromise ??= resolveAwsAccountId(datasetRegion));
   const queryIdentity = (
     filterString: string,
     queryOptions?: { requiredViewProperties?: string[]; scope?: 'target' | 'account' },
@@ -483,6 +534,9 @@ export const discoverAwsResources = async (
     loadedDatasetKeys.add(datasetKey);
     const startedAtMs = Date.now();
     const loadPromise = (async (): Promise<AwsDiscoveryDatasetLoad<K>> => {
+      const { catalog: inputCatalog, resources: matchingResources } = await resolveDatasetCatalog(
+        definition.resourceTypes,
+      );
       const result = (
         resources: unknown[],
         diagnostics: ScanDiagnostic[],
@@ -495,7 +549,6 @@ export const discoverAwsResources = async (
         ...(unavailableDiagnostics?.length ? { unavailableDiagnostics } : {}),
       });
       if (!accountScoped && catalogFailureDiagnostic) return result([], [], true);
-      const matchingResources = definition.resourceTypes.flatMap((type) => resourcesByType.get(type) ?? []);
       if (!accountScoped && region === undefined) {
         emitDebugLog(options?.debugLogger, `aws: loading dataset ${datasetKey}`);
         const groups = groupResourcesByRegion(matchingResources);
@@ -577,7 +630,12 @@ export const discoverAwsResources = async (
             region: region ?? datasetRegion,
             schemaVersion: definition.schemaVersion,
             loaderVersion: definition.loaderVersion,
-            catalog: { scope: catalogScope, viewArn: catalog.viewArn, resources: regionResources, queries: queryLoads },
+            catalog: {
+              scope: !accountScoped && isAwsEvidenceCacheEnabled() ? await resolveCatalogScope() : undefined,
+              viewArn: inputCatalog.viewArn,
+              resources: regionResources,
+              queries: queryLoads,
+            },
             observationWindow,
             dependencies: dependencyLoads.map((dependency) => [
               dependency.dataset[0],
@@ -595,10 +653,10 @@ export const discoverAwsResources = async (
                 [datasetKey]: loaded.resources,
               },
               {
-                ...catalog,
+                ...inputCatalog,
                 resources: region
-                  ? catalog.resources.filter((resource) => resource.region === region)
-                  : catalog.resources,
+                  ? inputCatalog.resources.filter((resource) => resource.region === region)
+                  : inputCatalog.resources,
               },
             );
             const value = { ...result(loaded.resources, loaded.diagnostics, loaded.unavailable), coverage };
@@ -681,22 +739,85 @@ export const discoverAwsResources = async (
     datasetLoadPromises.set(cacheKey, loadPromise as Promise<AwsDiscoveryDatasetLoad>);
     return loadPromise;
   };
+  const finalizeLoad = (load: AwsDiscoveryDatasetLoad): AwsDiscoveryDatasetLoad => {
+    if (!catalogFailureDiagnostic) return load;
+    const needsCatalog = resolveAwsDiscoveryDatasetDependencies([load.dataset[0]]).some(
+      (key) => (getAwsDiscoveryDatasetDefinition(key)?.resourceTypes.length ?? 0) > 0,
+    );
+    return needsCatalog
+      ? {
+          dataset: [load.dataset[0], []],
+          diagnostics: [],
+          unavailable: true,
+          unavailableDiagnostics: [catalogFailureDiagnostic],
+        }
+      : load;
+  };
   // The public operation owns one budget spanning catalog and dataset loads.
+  const completedLoads = new Map<DiscoveryDatasetKey, AwsDiscoveryDatasetLoad>();
+  const reportedRules = new Set<string>();
+  const notifyReadyRules = () => {
+    if (!options?.onRuleReady) return;
+    const readyRules = rules.filter((rule) => {
+      if (reportedRules.has(rule.id) || !rule.evaluateLive || !rule.supports.includes('discovery')) return false;
+      const dependencies = [
+        ...(rule.discoveryDependencies ?? []),
+        ...(rule.optionalDiscoveryDependencies ?? []).filter((key) => datasetKeys.includes(key)),
+      ];
+      return dependencies.every((key) => completedLoads.has(key));
+    });
+    if (readyRules.length === 0) return;
+    const snapshotLoads = [...completedLoads.values()].map(finalizeLoad);
+    const snapshot: LiveDiscoveryContext = {
+      catalog: catalogFailureDiagnostic
+        ? catalog
+        : {
+            ...([...readyCatalogs.values()][0] ?? catalog),
+            resources: [...readyCatalogs.values()]
+              .flatMap((input) => input.resources)
+              .sort((left, right) => left.arn.localeCompare(right.arn)),
+          },
+      diagnostics: [],
+      resources: new LiveResourceBag(
+        Object.fromEntries(snapshotLoads.map((load) => load.dataset)) as Partial<DiscoveryDatasetMap>,
+      ),
+      unavailableDatasets: new Map(
+        snapshotLoads
+          .filter((load) => load.unavailable)
+          .map((load) => [load.dataset[0], load.unavailableDiagnostics ?? load.diagnostics]),
+      ),
+      unavailableRegions,
+    };
+    for (const rule of readyRules) {
+      throwIfAwsExecutionAborted();
+      reportedRules.add(rule.id);
+      options.onRuleReady(rule, snapshot);
+    }
+  };
   let completedDatasets = 0;
-  const datasetLoads = await Promise.all(
-    datasetKeys.map(async (datasetKey) => {
-      const loadResult = await loadDataset(datasetKey);
-      completedDatasets += 1;
-      options?.onProgress?.({
-        kind: 'dataset',
-        completedDatasets,
-        datasetKey,
-        totalDatasets: datasetKeys.length,
-      });
-      return loadResult;
-    }),
-  );
-  const allDatasetLoads = await Promise.all([...loadedDatasetKeys].map((key) => loadDataset(key)));
+  const [, collectedDatasetLoads] = await Promise.all([
+    catalogReady,
+    Promise.all(
+      datasetKeys.map(async (datasetKey) => {
+        const loadResult = await loadDataset(datasetKey);
+        throwIfAwsExecutionAborted();
+        completedLoads.set(datasetKey, loadResult);
+        completedDatasets += 1;
+        options?.onProgress?.({
+          kind: 'dataset',
+          completedDatasets,
+          datasetKey,
+          totalDatasets: datasetKeys.length,
+        });
+        notifyReadyRules();
+        return loadResult;
+      }),
+    ),
+  ]);
+  const datasetLoads = collectedDatasetLoads.map(finalizeLoad);
+  const allDatasetLoads = (
+    await Promise.all((sortUnique([...loadedDatasetKeys]) as DiscoveryDatasetKey[]).map((key) => loadDataset(key)))
+  ).map(finalizeLoad);
   const resources = new LiveResourceBag(
     Object.fromEntries(datasetLoads.map((loadResult) => loadResult.dataset)) as Partial<DiscoveryDatasetMap>,
   );

--- a/packages/sdk/src/providers/aws/resource-explorer.ts
+++ b/packages/sdk/src/providers/aws/resource-explorer.ts
@@ -881,6 +881,7 @@ const listResourceExplorerResources = async (options: {
   queryLabel?: string;
   searchRegion: string;
   viewArn: string;
+  onQueryComplete?: (queryIndex: number, resources: AwsDiscoveredResource[], complete: boolean) => void;
 }): Promise<{ resources: AwsDiscoveredResource[]; complete: boolean }> => {
   const client = createResourceExplorerClient({ region: options.searchRegion });
   let complete = true;
@@ -890,6 +891,7 @@ const listResourceExplorerResources = async (options: {
   for (const [queryIndex, filterString] of options.filters.entries()) {
     let nextToken: string | undefined;
     let page = 1;
+    let queryComplete = true;
 
     do {
       emitDebugLog(
@@ -928,18 +930,60 @@ const listResourceExplorerResources = async (options: {
           resourcesByArn.set(normalized.arn, normalized);
         } else {
           complete = false;
+          queryComplete = false;
         }
       }
 
       nextToken = response.NextToken;
       page += 1;
     } while (nextToken);
+    throwIfAwsExecutionAborted();
+    options.onQueryComplete?.(queryIndex, [...resourcesByArn.values()], queryComplete);
   }
 
   return { resources: [...resourcesByArn.values()].sort((left, right) => left.arn.localeCompare(right.arn)), complete };
 };
 
 type CatalogMissResult = { value: AwsDiscoveredResource[]; complete: boolean };
+
+// A type is ready only when every plan covering its selected regions has drained.
+// Packed filters remain intact, including when one type spans several plans.
+const listCatalogResourceTypes = (options: {
+  searchPlan: SearchPlan;
+  resourceTypes: string[];
+  viewArn: string;
+  debugLogger?: (message: string) => void;
+  onResourceTypeReady: (resourceType: string, result: CatalogMissResult) => void;
+}): Promise<{ resources: AwsDiscoveredResource[]; complete: boolean }> => {
+  const plans = planListResourcesQueries(options.resourceTypes, options.searchPlan.regionFilters);
+  const remaining = new Map<string, number>();
+  const completeness = new Map<string, boolean>();
+  for (const plan of plans) {
+    for (const type of plan.resourceTypes) remaining.set(type, (remaining.get(type) ?? 0) + 1);
+  }
+  return listResourceExplorerResources({
+    debugLogger: options.debugLogger,
+    filters: plans.map((plan) => buildFilterString(plan.resourceTypes, plan.regionFilters)),
+    searchRegion: options.searchPlan.searchRegion,
+    viewArn: options.viewArn,
+    onQueryComplete: (index, resources, complete) => {
+      for (const type of plans[index]?.resourceTypes ?? []) {
+        const count = (remaining.get(type) ?? 1) - 1;
+        remaining.set(type, count);
+        completeness.set(type, (completeness.get(type) ?? true) && complete);
+        if (count === 0) {
+          options.onResourceTypeReady(type, {
+            value: resources
+              .filter((resource) => resource.resourceType === type)
+              .sort((left, right) => left.arn.localeCompare(right.arn)),
+            complete: completeness.get(type) ?? false,
+          });
+        }
+      }
+    },
+  });
+};
+
 type CatalogMiss = {
   resourceType: string;
   settled: boolean;
@@ -974,27 +1018,23 @@ const createCatalogMissBatcher = (options: {
       // The batch owns its clients and lifetime. In particular, cancellation of
       // the first type's detached cache loader cannot end another type's work.
       // Pinned credentials and the stable account request budget remain inherited.
-      const listed = await runOutsideAwsExecution(() =>
+      await runOutsideAwsExecution(() =>
         withAwsDiscoveryExecution(
           { signal: controller.signal, observationTimestamp, debugLogger: options.debugLogger },
           () =>
-            listResourceExplorerResources({
+            listCatalogResourceTypes({
               debugLogger: options.debugLogger,
-              filters: planListResourcesQueries(
-                batch.map((request) => request.resourceType),
-                options.searchPlan.regionFilters,
-              ).map((plan) => buildFilterString(plan.resourceTypes, plan.regionFilters)),
-              searchRegion: options.searchPlan.searchRegion,
+              resourceTypes: batch.map((request) => request.resourceType),
+              searchPlan: options.searchPlan,
               viewArn: options.viewArn,
+              onResourceTypeReady: (resourceType, result) => {
+                for (const request of batch) {
+                  if (request.resourceType === resourceType) request.finish(result);
+                }
+              },
             }),
         ),
       );
-      for (const request of batch) {
-        request.finish({
-          value: listed.resources.filter((resource) => resource.resourceType === request.resourceType),
-          complete: listed.complete,
-        });
-      }
     } catch (error) {
       for (const request of batch) request.finish(error as Error, true);
     }
@@ -1038,12 +1078,16 @@ const createCatalogMissBatcher = (options: {
  *
  * @param target - Discovery target that controls region or aggregator behavior.
  * @param resourceTypes - Resource Explorer resource types required by active rules.
+ * @param options - Logging and notification when a type's complete selected catalog scope is available.
  * @returns Catalog of discovered AWS resources plus search metadata.
  */
 export const buildAwsDiscoveryCatalog = async (
   target: AwsDiscoveryTarget,
   resourceTypes: string[],
-  options?: { debugLogger?: (message: string) => void },
+  options?: {
+    debugLogger?: (message: string) => void;
+    onResourceTypeReady?: (resourceType: string, catalog: AwsDiscoveryCatalog) => void;
+  },
 ): Promise<AwsDiscoveryCatalog> => {
   const searchPlan = await resolveCachedSearchPlan(target);
   emitDebugLog(
@@ -1053,6 +1097,15 @@ export const buildAwsDiscoveryCatalog = async (
     }`,
   );
   const viewArn = await resolveSearchViewArn(searchPlan.searchRegion);
+  const onResourceTypeReady = (resourceType: string, resources: AwsDiscoveredResource[]): void => {
+    throwIfAwsExecutionAborted();
+    options?.onResourceTypeReady?.(resourceType, {
+      resources,
+      searchRegion: searchPlan.searchRegion,
+      indexType: searchPlan.indexType,
+      viewArn,
+    });
+  };
   const queryPlans = planListResourcesQueries(resourceTypes, searchPlan.regionFilters);
   emitDebugLog(
     options?.debugLogger,
@@ -1076,6 +1129,7 @@ export const buildAwsDiscoveryCatalog = async (
           load: () => loadMissingType(resourceType),
           validate: isResourceList,
         });
+        onResourceTypeReady(resourceType, result.value);
         return result.value;
       }),
     );
@@ -1084,11 +1138,12 @@ export const buildAwsDiscoveryCatalog = async (
     );
   } else {
     resources = (
-      await listResourceExplorerResources({
+      await listCatalogResourceTypes({
         debugLogger: options?.debugLogger,
-        filters: queryPlans.map((queryPlan) => buildFilterString(queryPlan.resourceTypes, queryPlan.regionFilters)),
-        searchRegion: searchPlan.searchRegion,
+        resourceTypes,
+        searchPlan,
         viewArn,
+        onResourceTypeReady: (resourceType, result) => onResourceTypeReady(resourceType, result.value),
       })
     ).resources;
   }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -152,6 +152,20 @@ export type AwsDiscoveryProgressEvent =
       completedDatasets: number;
       datasetKey: DiscoveryDatasetKey;
       totalDatasets: number;
+    }
+  | {
+      kind: 'rule';
+      ruleId: string;
+      /** Every progress result is provisional; only the resolved scan applies final precedence. */
+      provisional: true;
+      status: RuleEvaluation['status'];
+      findingCount: number;
+      findings: FindingMatch[];
+      reason?: string;
+      completedRules: number;
+      totalRules: number;
+      /** Elapsed milliseconds since rule selection completed. */
+      elapsedMs: number;
     };
 
 /** Describes one enabled Resource Explorer index region. */

--- a/packages/sdk/test/discovery-http-integration.test.ts
+++ b/packages/sdk/test/discovery-http-integration.test.ts
@@ -6,7 +6,7 @@ import { ResourceExplorer2Client } from '@aws-sdk/client-resource-explorer-2';
 import { STSClient } from '@aws-sdk/client-sts';
 import type { HttpRequest } from '@aws-sdk/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CloudBurnClient, withAwsClientCredentials } from '../src/index.js';
+import { type AwsDiscoveryProgressEvent, CloudBurnClient, withAwsClientCredentials } from '../src/index.js';
 
 const fixture = (name: string): string =>
   readFileSync(new URL(`./fixtures/aws-discovery/${name}`, import.meta.url), 'utf8');
@@ -59,6 +59,7 @@ let debugMessages: string[];
 let admissionDirectory: string;
 let enabledRegions: string[] | undefined;
 let holdOperation: string | undefined;
+let holdLastCatalogPage: boolean;
 let failOperation: string | undefined;
 let transientOperation: string | undefined;
 let transientStatusCode: number;
@@ -70,6 +71,7 @@ beforeEach(() => {
   authorizations = [];
   enabledRegions = undefined;
   holdOperation = undefined;
+  holdLastCatalogPage = false;
   failOperation = undefined;
   transientOperation = undefined;
   transientStatusCode = 500;
@@ -121,7 +123,7 @@ beforeEach(() => {
         },
       };
     }
-    if (operation === holdOperation) {
+    if (operation === holdOperation && (!holdLastCatalogPage || JSON.parse(body).NextToken)) {
       return new Promise((resolve, reject) => {
         const signal = options?.abortSignal as AbortSignal;
         const onAbort = () => reject(signal.reason);
@@ -139,12 +141,17 @@ beforeEach(() => {
                       headers: { 'content-type': 'text/xml' },
                       body: Buffer.from(fixture('volumes.xml')),
                     }
-                  : { statusCode: 200, headers: { 'content-type': 'application/json' }, body: Buffer.from('{}') },
+                  : {
+                      statusCode: 200,
+                      headers: { 'content-type': 'application/json' },
+                      body: Buffer.from(operation === 'ListResources' ? fixture('resources-last.json') : '{}'),
+                    },
             });
           },
         });
       });
     }
+    if (operation === 'GetAnomalyMonitors') return jsonResponse({ AnomalyMonitors: [] });
     if (request.hostname === 'resource-explorer-2.eu-west-1.amazonaws.com') {
       if (operation === 'ListSupportedResourceTypes') {
         const input = body ? JSON.parse(body) : request.query;
@@ -194,6 +201,7 @@ beforeEach(() => {
         }
         const input = body ? JSON.parse(body) : request.query;
         const value = JSON.parse(fixture(input.NextToken ? 'resources-last.json' : 'resources-first.json'));
+        if (holdLastCatalogPage && !input.NextToken) value.Resources = [];
         if (includeNewVolume && input.NextToken)
           value.Resources.push({
             ...value.Resources[0],
@@ -343,6 +351,189 @@ it('discovers through real AWS serialization, catalog pagination, hydration and 
   expect(requests.filter((request) => request.operation === 'GetCallerIdentity')).toHaveLength(1);
   // Findings retain their resource account; quotas use the signing caller's account.
   expect(volumeAttempt()).toMatchObject({ quota: { accountId: '222222222222' } });
+});
+
+// Public cancellation rejects promptly; let the detached request release its
+// SQLite lease before this fixture deletes its private admission directory.
+const waitForCancelledCatalogCleanup = async () => {
+  if (held.length === 0) return;
+  await vi.waitFor(() =>
+    expect(
+      debugMessages
+        .filter((message) => message.startsWith('aws: attempt '))
+        .map((message) => JSON.parse(message.slice('aws: attempt '.length)))
+        .some(
+          (attempt) =>
+            attempt.operation === 'ListResources' &&
+            attempt.outcome === 'cancelled' &&
+            attempt.cleanupOutcome === 'released',
+        ),
+    ).toBe(true),
+  );
+};
+
+it('collects independent account evidence while catalog pagination is blocked', async () => {
+  holdOperation = 'ListResources';
+  const controller = new AbortController();
+  const scan = new CloudBurnClient({ debugLogger: (message) => debugMessages.push(message) }).discover({
+    signal: controller.signal,
+    aws: { credentials: { accessKeyId: 'SYNTHETIC', secretAccessKey: 'synthetic-test-key' } },
+    target: { mode: 'region', region },
+    config: { discovery: { enabledRules: ['CLDBRN-AWS-EBS-1', 'CLDBRN-AWS-COSTGUARDRAILS-2'] } },
+  });
+  const outcome = scan.catch((error: unknown) => error);
+  try {
+    await vi.waitFor(() => expect(held.length).toBeGreaterThan(0), { timeout: 4000 });
+    await vi.waitFor(() => expect(requests.some(({ operation }) => operation === 'GetAnomalyMonitors')).toBe(true));
+  } finally {
+    controller.abort();
+    await outcome;
+    await waitForCancelledCatalogCleanup();
+  }
+});
+
+it('reports provisional evaluated findings before unrelated hydration completes', async () => {
+  holdOperation = 'DescribeVolumes';
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const controller = new AbortController();
+  const scan = new CloudBurnClient({ debugLogger: (message) => debugMessages.push(message) }).discover({
+    signal: controller.signal,
+    aws: { credentials: { accessKeyId: 'SYNTHETIC', secretAccessKey: 'synthetic-test-key' } },
+    target: { mode: 'region', region },
+    config: { discovery: { enabledRules: ['CLDBRN-AWS-EBS-1', 'CLDBRN-AWS-COSTGUARDRAILS-2'] } },
+    includeEvaluationResources: true,
+    onProgress: (event) => events.push(event),
+  });
+  const outcome = scan.catch((error: unknown) => error);
+  try {
+    await vi.waitFor(() => expect(held.length).toBeGreaterThan(0), { timeout: 4000 });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: 'rule',
+        ruleId: 'CLDBRN-AWS-COSTGUARDRAILS-2',
+        provisional: true,
+        status: 'triggered',
+        findingCount: 1,
+      }),
+    );
+    expect(events.filter((event) => event.kind === 'rule')).toHaveLength(1);
+    held[0]?.release();
+    const result = await scan;
+    expect(result.providers.flatMap((provider) => provider.rules).map((rule) => rule.ruleId)).toEqual([
+      'CLDBRN-AWS-COSTGUARDRAILS-2',
+      'CLDBRN-AWS-EBS-1',
+    ]);
+    expect(events.filter((event) => event.kind === 'rule')).toHaveLength(2);
+    const timingLog = debugMessages.find((message) => message.startsWith('sdk: live scan timing '));
+    expect(timingLog).toBeDefined();
+    const timing = JSON.parse(timingLog?.slice('sdk: live scan timing '.length) ?? '{}');
+    expect(timing.firstRuleMs).toBe(events.find((event) => event.kind === 'rule')?.elapsedMs);
+    expect(timing.totalMs).toBeGreaterThan(timing.firstRuleMs);
+  } finally {
+    controller.abort();
+    await outcome;
+  }
+});
+
+it('evaluates a cached catalog scope while an unrelated catalog miss is blocked', async () => {
+  const client = new CloudBurnClient({ debugLogger: (message) => debugMessages.push(message) });
+  const cache = { directory: join(admissionDirectory, 'evidence'), authorizationContext: 'synthetic-policy-v1' };
+  const aws = { credentials: { accessKeyId: 'SYNTHETIC', secretAccessKey: 'synthetic-test-key' } };
+  await client.discover({
+    cache,
+    aws,
+    target: { mode: 'region', region },
+    config: { discovery: { enabledRules: ['CLDBRN-AWS-EBS-1'] } },
+  });
+  holdOperation = 'ListResources';
+  const controller = new AbortController();
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const scan = client.discover({
+    cache,
+    aws,
+    signal: controller.signal,
+    target: { mode: 'region', region },
+    config: { discovery: { enabledRules: ['CLDBRN-AWS-EBS-1', 'CLDBRN-AWS-CLOUDWATCH-1'] } },
+    onProgress: (event) => events.push(event),
+  });
+  const outcome = scan.catch((error: unknown) => error);
+  try {
+    await vi.waitFor(() => expect(held.length).toBeGreaterThan(0), { timeout: 4000 });
+    await vi.waitFor(() =>
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          kind: 'rule',
+          ruleId: 'CLDBRN-AWS-EBS-1',
+          status: 'triggered',
+          findingCount: 1,
+        }),
+      ),
+    );
+    expect(events.some((event) => event.kind === 'catalog')).toBe(false);
+  } finally {
+    controller.abort();
+    await outcome;
+    await waitForCancelledCatalogCleanup();
+  }
+});
+
+it('never evaluates absence from an empty catalog page with more pages pending', async () => {
+  holdOperation = 'ListResources';
+  holdLastCatalogPage = true;
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const controller = new AbortController();
+  const scan = new CloudBurnClient().discover({
+    signal: controller.signal,
+    aws: { credentials: { accessKeyId: 'SYNTHETIC', secretAccessKey: 'synthetic-test-key' } },
+    target: { mode: 'region', region },
+    config: { discovery: { enabledRules: ['CLDBRN-AWS-EBS-1'] } },
+    onProgress: (event) => events.push(event),
+  });
+  const outcome = scan.catch((error: unknown) => error);
+  try {
+    await vi.waitFor(() => expect(held).toHaveLength(1), { timeout: 4000 });
+    expect(events).toEqual([]);
+    expect(requests.some(({ operation }) => operation === 'DescribeVolumes')).toBe(false);
+    held[0]?.release();
+    const result = await scan;
+    expect(result.providers[0]?.rules[0]?.findings).toEqual([
+      { accountId, region, resourceId: 'vol-legacy', resourceType: 'ec2:volume' },
+    ]);
+    expect(events).toContainEqual(expect.objectContaining({ kind: 'rule', status: 'triggered', findingCount: 1 }));
+  } finally {
+    controller.abort();
+    await outcome;
+  }
+});
+
+it('rejects cancellation after useful progress and stops active transport and later events', async () => {
+  holdOperation = 'DescribeVolumes';
+  const controller = new AbortController();
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const scan = new CloudBurnClient().discover({
+    signal: controller.signal,
+    aws: { credentials: { accessKeyId: 'SYNTHETIC', secretAccessKey: 'synthetic-test-key' } },
+    target: { mode: 'region', region },
+    config: { discovery: { enabledRules: ['CLDBRN-AWS-EBS-1', 'CLDBRN-AWS-COSTGUARDRAILS-2'] } },
+    onProgress: (event) => events.push(event),
+  });
+  const outcome = scan.catch((error: unknown) => error);
+  try {
+    await vi.waitFor(() => expect(held).toHaveLength(1), { timeout: 4000 });
+    expect(events.some((event) => event.kind === 'rule')).toBe(true);
+    const eventCount = events.length;
+    const requestCount = requests.length;
+    controller.abort();
+    expect(await outcome).toMatchObject({ name: 'AbortError' });
+    expect(held[0]?.signal.aborted).toBe(true);
+    held[0]?.release();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(events).toHaveLength(eventCount);
+    expect(requests).toHaveLength(requestCount);
+  } finally {
+    controller.abort();
+    await outcome;
+  }
 });
 
 it('reuses complete evidence across scans while re-evaluating rule selection', async () => {

--- a/packages/sdk/test/discovery-pipeline-evaluation.test.ts
+++ b/packages/sdk/test/discovery-pipeline-evaluation.test.ts
@@ -1,0 +1,356 @@
+import { CostExplorerClient, GetSavingsPlansCoverageCommand } from '@aws-sdk/client-cost-explorer';
+import {
+  CostOptimizationHubClient,
+  GetRecommendationCommand,
+  ListEnrollmentStatusesCommand,
+  ListRecommendationsCommand,
+} from '@aws-sdk/client-cost-optimization-hub';
+import { DescribeInstancesCommand, DescribeVolumesCommand, EC2Client } from '@aws-sdk/client-ec2';
+import { STSClient } from '@aws-sdk/client-sts';
+import type { AwsDiscoveryCatalog } from '@cloudburn/rules';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { runLiveScan } from '../src/engine/run-live.js';
+import { buildAwsDiscoveryCatalog } from '../src/providers/aws/resource-explorer.js';
+import type { AwsDiscoveryProgressEvent } from '../src/types.js';
+
+vi.mock('../src/providers/aws/resource-explorer.js', async (original) => ({
+  ...(await original<typeof import('../src/providers/aws/resource-explorer.js')>()),
+  buildAwsDiscoveryCatalog: vi.fn(),
+}));
+
+const accountId = '123456789012';
+const region = 'eu-west-1';
+const nativeRule = 'CLDBRN-AWS-EBS-2';
+const idleHubRule = 'CLDBRN-AWS-COSTOPTIMIZATIONHUB-3';
+const savingsHubRule = 'CLDBRN-AWS-COSTOPTIMIZATIONHUB-1';
+const coverageRule = 'CLDBRN-AWS-SAGEMAKER-3';
+const previousGenerationRule = 'CLDBRN-AWS-EC2-8';
+const catalogFor = (resourceType = 'ec2:volume', regions = [region]): AwsDiscoveryCatalog => ({
+  indexType: 'AGGREGATOR',
+  searchRegion: region,
+  viewArn: 'synthetic-view',
+  resources: regions.map((resourceRegion) => ({
+    accountId,
+    region: resourceRegion,
+    resourceType,
+    service: 'ec2',
+    arn: `arn:aws:ec2:${resourceRegion}:${accountId}:${resourceType === 'ec2:volume' ? 'volume/vol-test' : 'instance/i-test'}`,
+  })),
+});
+const volumeResponse = { Volumes: [{ VolumeId: 'vol-test', VolumeType: 'gp3', Size: 20, Attachments: [] }] };
+const instanceResponse = { Reservations: [{ Instances: [{ InstanceId: 'i-test', InstanceType: 'm5.24xlarge' }] }] };
+const idleRecommendation = {
+  accountId,
+  region,
+  resourceId: `arn:aws:ec2:${region}:${accountId}:volume/vol-test`,
+  actionType: 'Delete',
+  currentResourceType: 'EbsVolume',
+  currencyCode: 'USD',
+  estimatedMonthlyCost: 20,
+  estimatedMonthlySavings: 20,
+  estimatedSavingsPercentage: 100,
+  implementationEffort: 'Low',
+  restartNeeded: false,
+  rollbackPossible: false,
+  recommendationId: 'idle-volume',
+  source: 'ComputeOptimizer',
+  lastRefreshTimestamp: new Date('2026-09-04T00:00:00Z'),
+};
+const run = (enabledRules: string[], onProgress?: (event: AwsDiscoveryProgressEvent) => void) =>
+  runLiveScan({ discovery: { enabledRules } }, { mode: 'all' }, { includeEvaluationResources: true, onProgress });
+const ruleEvents = (events: AwsDiscoveryProgressEvent[]) => events.filter((event) => event.kind === 'rule');
+
+beforeEach(() => {
+  vi.stubEnv('AWS_REGION', region);
+  vi.spyOn(STSClient.prototype, 'send').mockResolvedValue({ Account: accountId } as never);
+  vi.mocked(buildAwsDiscoveryCatalog).mockImplementation(async (_target, _types, options) => {
+    const catalog = catalogFor();
+    options?.onResourceTypeReady?.('ec2:volume', catalog);
+    return catalog;
+  });
+  vi.spyOn(EC2Client.prototype, 'send').mockImplementation(async (command) => {
+    if (command instanceof DescribeVolumesCommand) return volumeResponse;
+    if (command instanceof DescribeInstancesCommand) return instanceResponse;
+    throw new Error(`Unexpected EC2 command: ${command.constructor.name}`);
+  });
+  vi.spyOn(CostOptimizationHubClient.prototype, 'send').mockImplementation(async (command) => {
+    if (command instanceof ListEnrollmentStatusesCommand) return { items: [{ accountId, status: 'Active' }] };
+    if (command instanceof ListRecommendationsCommand) return { items: [idleRecommendation] };
+    if (command instanceof GetRecommendationCommand)
+      return { currentResourceDetails: { ebsVolume: { configuration: { storage: { type: 'gp3', sizeInGb: 20 } } } } };
+    throw new Error(`Unexpected Hub command: ${command.constructor.name}`);
+  });
+  vi.spyOn(CostExplorerClient.prototype, 'send').mockImplementation(async (command) => {
+    if (command instanceof GetSavingsPlansCoverageCommand)
+      return {
+        SavingsPlansCoverages: [
+          {
+            Coverage: {
+              CoveragePercentage: '60',
+              OnDemandCost: '100',
+              SpendCoveredBySavingsPlans: '150',
+              TotalCost: '250',
+            },
+            TimePeriod: { End: '2026-09-04', Start: '2026-08-05' },
+          },
+        ],
+      };
+    throw new Error(`Unexpected Cost Explorer command: ${command.constructor.name}`);
+  });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+it('reports provisional Hub evidence before native evidence and preserves final finding precedence', async () => {
+  const volumeGate = Promise.withResolvers<void>();
+  vi.mocked(EC2Client.prototype.send).mockImplementation(async (command) => {
+    if (!(command instanceof DescribeVolumesCommand)) throw new Error('Unexpected EC2 command');
+    await volumeGate.promise;
+    return volumeResponse;
+  });
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const selected = [idleHubRule, nativeRule];
+  const pending = run(selected, (event) => events.push(event));
+  try {
+    await vi.waitFor(() =>
+      expect(ruleEvents(events)).toContainEqual(
+        expect.objectContaining({
+          ruleId: idleHubRule,
+          provisional: true,
+          status: 'triggered',
+          findingCount: 1,
+          findings: [{ accountId, region, resourceId: 'vol-test', resourceType: 'ec2:volume', actionType: 'Delete' }],
+        }),
+      ),
+    );
+    expect(ruleEvents(events).some((event) => event.ruleId === nativeRule)).toBe(false);
+    volumeGate.resolve();
+    const result = await pending;
+    expect(result.providers.flatMap((provider) => provider.rules).map((rule) => rule.ruleId)).toEqual([nativeRule]);
+    expect(result.evaluations?.rules.find((rule) => rule.ruleId === idleHubRule)).toMatchObject({
+      status: 'triggered',
+      findingCount: 1,
+    });
+    expect(ruleEvents(events).find((event) => event.ruleId === nativeRule)).toMatchObject({
+      provisional: true,
+      status: 'triggered',
+      findingCount: 1,
+    });
+    expect(result).toEqual(await run(selected));
+  } finally {
+    volumeGate.resolve();
+    await pending;
+  }
+});
+
+it('waits for selected optional recommendations before evaluating SageMaker coverage', async () => {
+  const recommendationsGate = Promise.withResolvers<void>();
+  vi.mocked(CostOptimizationHubClient.prototype.send).mockImplementation(async (command) => {
+    if (command instanceof ListEnrollmentStatusesCommand) return { items: [{ accountId, status: 'Active' }] };
+    if (command instanceof ListRecommendationsCommand) {
+      await recommendationsGate.promise;
+      return {
+        items: [
+          {
+            accountId,
+            actionType: 'PurchaseSavingsPlans',
+            currencyCode: 'USD',
+            currentResourceType: 'SageMakerSavingsPlans',
+            estimatedMonthlyCost: 200,
+            estimatedMonthlySavings: 50,
+            estimatedSavingsPercentage: 25,
+            lastRefreshTimestamp: new Date('2026-09-03T00:00:00Z'),
+            recommendationId: 'sagemaker-purchase',
+            source: 'CostExplorer',
+          },
+        ],
+      };
+    }
+    if (command instanceof GetRecommendationCommand)
+      return {
+        recommendationId: 'sagemaker-purchase',
+        recommendedResourceDetails: {
+          sageMakerSavingsPlans: {
+            configuration: {
+              accountScope: 'LINKED',
+              hourlyCommitment: '0.42',
+              paymentOption: 'NoUpfront',
+              term: 'OneYear',
+            },
+          },
+        },
+      };
+    throw new Error('Unexpected Hub command');
+  });
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const selected = [coverageRule, savingsHubRule];
+  const pending = run(selected, (event) => events.push(event));
+  try {
+    await vi.waitFor(() =>
+      expect(events).toContainEqual(
+        expect.objectContaining({ kind: 'dataset', datasetKey: 'aws-sagemaker-savings-plans-coverage' }),
+      ),
+    );
+    expect(ruleEvents(events)).toEqual([]);
+    recommendationsGate.resolve();
+    const result = await pending;
+    expect(ruleEvents(events).find((event) => event.ruleId === coverageRule)).toMatchObject({
+      provisional: true,
+      status: 'passed',
+      findingCount: 0,
+      findings: [],
+    });
+    expect(result.providers.flatMap((provider) => provider.rules).map((rule) => rule.ruleId)).toEqual([savingsHubRule]);
+    expect(result.evaluations?.rules.find((rule) => rule.ruleId === coverageRule)).toMatchObject({
+      status: 'passed',
+      findingCount: 0,
+    });
+    expect(result).toEqual(await run(selected));
+  } finally {
+    recommendationsGate.resolve();
+    await pending;
+  }
+});
+
+it('preserves healthy regional progress and final evaluation evidence while another dataset remains blocked', async () => {
+  const regions = ['eu-west-1', 'us-east-1', 'eu-central-1'];
+  vi.mocked(buildAwsDiscoveryCatalog).mockImplementation(async (_target, _types, options) => {
+    const catalog = catalogFor('ec2:instance', regions);
+    options?.onResourceTypeReady?.('ec2:instance', catalog);
+    return catalog;
+  });
+  vi.mocked(EC2Client.prototype.send).mockImplementation(async function (this: EC2Client, command) {
+    if (!(command instanceof DescribeInstancesCommand)) throw new Error('Unexpected EC2 command');
+    if ((await this.config.region()) === 'us-east-1') throw new Error('synthetic regional outage');
+    return instanceResponse;
+  });
+  const hubGate = Promise.withResolvers<void>();
+  vi.mocked(CostOptimizationHubClient.prototype.send).mockImplementation(async (command) => {
+    if (command instanceof ListEnrollmentStatusesCommand) return { items: [{ accountId, status: 'Active' }] };
+    if (command instanceof ListRecommendationsCommand) {
+      await hubGate.promise;
+      return { items: [] };
+    }
+    throw new Error('Unexpected Hub command');
+  });
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const selected = [previousGenerationRule, idleHubRule];
+  const pending = run(selected, (event) => events.push(event));
+  try {
+    await vi.waitFor(() =>
+      expect(ruleEvents(events).find((event) => event.ruleId === previousGenerationRule)).toMatchObject({
+        provisional: true,
+        status: 'triggered',
+        findingCount: 2,
+        reason: expect.stringContaining('us-east-1'),
+      }),
+    );
+    expect(
+      ruleEvents(events)
+        .find((event) => event.ruleId === previousGenerationRule)
+        ?.findings.map((finding) => finding.region)
+        .sort(),
+    ).toEqual(['eu-central-1', 'eu-west-1']);
+    expect(ruleEvents(events).some((event) => event.ruleId === idleHubRule)).toBe(false);
+    hubGate.resolve();
+    const result = await pending;
+    const evaluation = result.evaluations?.rules.find((rule) => rule.ruleId === previousGenerationRule);
+    expect(
+      result.evaluations?.resourceSets.find((set) => set.id === evaluation?.resourceSetId)?.resources,
+    ).toHaveLength(2);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({ region: 'us-east-1', status: 'error' }));
+    expect(result).toEqual(await run(selected));
+  } finally {
+    hubGate.resolve();
+    await pending;
+  }
+});
+
+it('discards earlier catalog-backed provisional findings after a later catalog failure while retaining account evidence', async () => {
+  const catalogFailure = Promise.withResolvers<void>();
+  vi.mocked(buildAwsDiscoveryCatalog).mockImplementation(async (_target, _types, options) => {
+    options?.onResourceTypeReady?.('ec2:volume', catalogFor());
+    await catalogFailure.promise;
+    throw new Error('synthetic later catalog page failed');
+  });
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const selected = [nativeRule, previousGenerationRule, idleHubRule];
+  const pending = run(selected, (event) => events.push(event));
+  try {
+    await vi.waitFor(() =>
+      expect(ruleEvents(events).find((event) => event.ruleId === nativeRule)).toMatchObject({
+        provisional: true,
+        status: 'triggered',
+        findingCount: 1,
+      }),
+    );
+    catalogFailure.resolve();
+    const result = await pending;
+    expect(result.providers.flatMap((provider) => provider.rules).map((rule) => rule.ruleId)).toEqual([idleHubRule]);
+    expect(result.evaluations?.rules.find((rule) => rule.ruleId === nativeRule)).toMatchObject({
+      status: 'not_applicable',
+      findingCount: 0,
+    });
+    expect(result.evaluations?.rules.find((rule) => rule.ruleId === previousGenerationRule)).toMatchObject({
+      status: 'not_applicable',
+      findingCount: 0,
+    });
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining('only account-scoped datasets were evaluated') }),
+    );
+    expect(result).toEqual(await run(selected));
+  } finally {
+    catalogFailure.resolve();
+    await pending;
+  }
+});
+
+it('reports catalog-backed work that finishes after a known catalog failure as not applicable', async () => {
+  const catalogFailure = Promise.withResolvers<void>();
+  const volumeStarted = Promise.withResolvers<void>();
+  const volumeResponseGate = Promise.withResolvers<void>();
+  vi.mocked(buildAwsDiscoveryCatalog).mockImplementation(async (_target, _types, options) => {
+    options?.onResourceTypeReady?.('ec2:volume', catalogFor());
+    await catalogFailure.promise;
+    throw new Error('synthetic catalog failed while hydration was running');
+  });
+  vi.mocked(EC2Client.prototype.send).mockImplementation(async (command) => {
+    if (!(command instanceof DescribeVolumesCommand)) throw new Error('Unexpected EC2 command');
+    volumeStarted.resolve();
+    await volumeResponseGate.promise;
+    return volumeResponse;
+  });
+  const events: AwsDiscoveryProgressEvent[] = [];
+  const pending = run([nativeRule, previousGenerationRule, idleHubRule], (event) => events.push(event));
+  try {
+    await volumeStarted.promise;
+    catalogFailure.resolve();
+    // The unresolved instance scope becomes unavailable only after orchestration
+    // has handled the failure; keep the earlier volume response held until then.
+    await vi.waitFor(() =>
+      expect(ruleEvents(events).find((event) => event.ruleId === previousGenerationRule)).toMatchObject({
+        status: 'not_applicable',
+      }),
+    );
+    expect(ruleEvents(events).some((event) => event.ruleId === nativeRule)).toBe(false);
+    volumeResponseGate.resolve();
+    const result = await pending;
+    expect(ruleEvents(events).find((event) => event.ruleId === nativeRule)).toMatchObject({
+      provisional: true,
+      status: 'not_applicable',
+      findingCount: 0,
+      findings: [],
+    });
+    expect(result.providers.flatMap((provider) => provider.rules).map((rule) => rule.ruleId)).toEqual([idleHubRule]);
+    expect(result.evaluations?.rules.find((rule) => rule.ruleId === nativeRule)).toMatchObject({
+      status: 'not_applicable',
+      findingCount: 0,
+    });
+  } finally {
+    catalogFailure.resolve();
+    volumeResponseGate.resolve();
+    await pending;
+  }
+});

--- a/packages/sdk/test/providers/aws-discovery.test.ts
+++ b/packages/sdk/test/providers/aws-discovery.test.ts
@@ -665,13 +665,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'ec2:instance',
-      'ec2:volume',
-      'ecr:repository',
-      'lambda:function',
-      's3:bucket',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['ec2:instance', 'ec2:volume', 'ecr:repository', 'lambda:function', 's3:bucket'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsEbsVolumes).toHaveBeenCalledWith([catalog.resources[0]], loadContextMatcher);
     expect(mockedHydrateAwsEc2Instances).toHaveBeenCalledWith([catalog.resources[1]], loadContextMatcher);
     expect(mockedHydrateAwsEcrRepositories).toHaveBeenCalledWith([catalog.resources[2]], loadContextMatcher);
@@ -909,13 +907,17 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'cloudfront:distribution',
-      'dynamodb:table',
-      'route53:healthcheck',
-      'route53:hostedzone',
-      'secretsmanager:secret',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      [
+        'cloudfront:distribution',
+        'dynamodb:table',
+        'route53:healthcheck',
+        'route53:hostedzone',
+        'secretsmanager:secret',
+      ],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsCloudFrontDistributions).toHaveBeenCalledWith(
       [extendedCatalog.resources[1]],
       loadContextMatcher,
@@ -1391,9 +1393,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'cloudtrail:trail',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['cloudtrail:trail'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsCloudTrailTrails).toHaveBeenCalledWith([catalog.resources[6]], loadContextMatcher);
     expect(result.resources.get('aws-cloudtrail-trails')).toEqual([
       {
@@ -1445,9 +1449,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'lambda:function',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['lambda:function'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsLambdaFunctions).toHaveBeenCalledWith([catalog.resources[3]], loadContextMatcher);
     expect(mockedHydrateAwsLambdaFunctionMetrics).toHaveBeenCalledWith([catalog.resources[3]], loadContextMatcher);
     expect(result.resources.get('aws-lambda-function-metrics')).toEqual([
@@ -1926,12 +1932,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'ecs:cluster',
-      'ecs:container-instance',
-      'ecs:service',
-      'eks:cluster',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['ecs:cluster', 'ecs:container-instance', 'ecs:service', 'eks:cluster'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsEcsContainerInstances).toHaveBeenCalledWith([catalog.resources[11]], loadContextMatcher);
     expect(mockedHydrateAwsEcsClusters).toHaveBeenCalledWith([catalog.resources[12]], loadContextMatcher);
     expect(mockedHydrateAwsEcsClusterMetrics).toHaveBeenCalledWith([catalog.resources[12]], loadContextMatcher);
@@ -2110,12 +2115,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'elasticache:cluster',
-      'elasticache:reserved-instance',
-      'elasticmapreduce:cluster',
-      'redshift:cluster',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['elasticache:cluster', 'elasticache:reserved-instance', 'elasticmapreduce:cluster', 'redshift:cluster'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsElastiCacheClusters).toHaveBeenCalledWith([catalog.resources[15]], loadContextMatcher);
     expect(mockedHydrateAwsElastiCacheReservedNodes).toHaveBeenCalledWith([catalog.resources[16]], loadContextMatcher);
     expect(mockedHydrateAwsEmrClusters).toHaveBeenCalledWith([catalog.resources[17]], loadContextMatcher);
@@ -2155,9 +2159,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'logs:log-group',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['logs:log-group'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsCloudWatchLogGroups).toHaveBeenCalledWith([catalog.resources[7]], loadContextMatcher);
     expect(result.resources.get('aws-cloudwatch-log-groups')).toEqual([
       {
@@ -2208,9 +2214,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'logs:log-group',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['logs:log-group'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsCloudWatchLogGroups).toHaveBeenCalledWith([catalog.resources[7]], loadContextMatcher);
     expect(mockedHydrateAwsCloudWatchLogStreams).toHaveBeenCalledWith([catalog.resources[7]], loadContextMatcher);
     expect(result.resources.get('aws-cloudwatch-log-groups')).toEqual([
@@ -2274,9 +2282,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'logs:log-group',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['logs:log-group'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsCloudWatchLogGroups).toHaveBeenCalledWith([catalog.resources[7]], loadContextMatcher);
     expect(mockedHydrateAwsCloudWatchLogGroupRecentStreamActivity).toHaveBeenCalledWith(
       [catalog.resources[7]],
@@ -2354,9 +2364,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'kms:key',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['kms:key'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsKmsKeyChurnReviews).toHaveBeenCalledWith([kmsResource], loadContextMatcher);
     expect(mockedHydrateAwsKmsKeyChurnReviews).toHaveBeenCalledTimes(1);
     expect(mockedHydrateAwsKmsKeyUsage).toHaveBeenCalledTimes(1);
@@ -2393,9 +2405,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      's3:bucket',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['s3:bucket'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsS3BucketAnalyses).toHaveBeenCalledWith([catalog.resources[4]], loadContextMatcher);
     expect(mockedHydrateAwsEbsVolumes).not.toHaveBeenCalled();
     expect(mockedHydrateAwsEc2Instances).not.toHaveBeenCalled();
@@ -2453,14 +2467,18 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'ec2:reserved-instances',
-      'elasticloadbalancing:loadbalancer',
-      'elasticloadbalancing:loadbalancer/app',
-      'elasticloadbalancing:loadbalancer/gwy',
-      'elasticloadbalancing:loadbalancer/net',
-      'elasticloadbalancing:targetgroup',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      [
+        'ec2:reserved-instances',
+        'elasticloadbalancing:loadbalancer',
+        'elasticloadbalancing:loadbalancer/app',
+        'elasticloadbalancing:loadbalancer/gwy',
+        'elasticloadbalancing:loadbalancer/net',
+        'elasticloadbalancing:targetgroup',
+      ],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsEc2ReservedInstances).toHaveBeenCalledWith([catalog.resources[8]], loadContextMatcher);
     expect(mockedHydrateAwsEc2LoadBalancers).toHaveBeenCalledWith([catalog.resources[9]], loadContextMatcher);
     expect(mockedHydrateAwsEc2TargetGroups).toHaveBeenCalledWith([catalog.resources[10]], loadContextMatcher);
@@ -2522,9 +2540,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'rds:db',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['rds:db'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsRdsInstances).toHaveBeenCalledWith([catalog.resources[5]], loadContextMatcher);
     expect(result.resources.get('aws-rds-instances' as never)).toEqual([
       {
@@ -2575,9 +2595,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'rds:db',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['rds:db'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsRdsInstances).toHaveBeenCalledWith([catalog.resources[5]], loadContextMatcher);
     expect(mockedHydrateAwsRdsInstanceCpuMetrics).toHaveBeenCalledWith([catalog.resources[5]], loadContextMatcher);
     expect(result.resources.get('aws-rds-instance-cpu-metrics')).toEqual([
@@ -2619,9 +2641,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'rds:db',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['rds:db'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsRdsReservedInstances).toHaveBeenCalledWith([catalog.resources[5]], loadContextMatcher);
     expect(result.resources.get('aws-rds-reserved-instances')).toEqual([
       {
@@ -2674,9 +2698,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'ec2:instance',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['ec2:instance'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsEc2Instances).toHaveBeenCalledWith([catalog.resources[1]], loadContextMatcher);
     expect(mockedHydrateAwsEc2InstanceUtilization).toHaveBeenCalledWith([catalog.resources[1]], loadContextMatcher);
     expect(result.resources.get('aws-ec2-instance-utilization')).toEqual([
@@ -2729,9 +2755,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'ec2:natgateway',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['ec2:natgateway'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsEc2NatGatewayActivity).toHaveBeenCalledWith(
       [
         {
@@ -2798,9 +2826,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'ec2:transit-gateway-attachment',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['ec2:transit-gateway-attachment'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsEc2TransitGatewayVpcAttachmentActivity).toHaveBeenCalledWith(
       [attachmentResource],
       loadContextMatcher,
@@ -2845,9 +2875,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'rds:db',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['rds:db'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsRdsInstances).toHaveBeenCalledWith([catalog.resources[5]], loadContextMatcher);
     expect(mockedHydrateAwsRdsInstanceActivity).toHaveBeenCalledWith([catalog.resources[5]], loadContextMatcher);
     expect(result.resources.get('aws-rds-instance-activity')).toEqual([
@@ -2889,9 +2921,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'ec2:snapshot',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['ec2:snapshot'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsEbsSnapshots).toHaveBeenCalledWith([catalog.resources[19]], loadContextMatcher);
     expect(result.resources.get('aws-ebs-snapshots')).toEqual([
       {
@@ -2933,9 +2967,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['us-east-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['us-east-1'] }, [
-      'rds:snapshot',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['us-east-1'] },
+      ['rds:snapshot'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsRdsSnapshots).toHaveBeenCalledWith([catalog.resources[20]], loadContextMatcher);
     expect(result.resources.get('aws-rds-snapshots')).toEqual([
       {
@@ -2985,9 +3021,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['eu-west-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['eu-west-1'] }, [
-      'sagemaker:notebook-instance',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['eu-west-1'] },
+      ['sagemaker:notebook-instance'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsSageMakerNotebookInstances).toHaveBeenCalledWith(
       [
         {
@@ -3052,9 +3090,11 @@ describe('discoverAwsResources', () => {
       { mode: 'regions', regions: ['eu-west-1'] },
     );
 
-    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith({ mode: 'regions', regions: ['eu-west-1'] }, [
-      'sagemaker:endpoint',
-    ]);
+    expect(mockedBuildAwsDiscoveryCatalog).toHaveBeenCalledWith(
+      { mode: 'regions', regions: ['eu-west-1'] },
+      ['sagemaker:endpoint'],
+      expect.objectContaining({ onResourceTypeReady: expect.any(Function) }),
+    );
     expect(mockedHydrateAwsSageMakerEndpointActivity).toHaveBeenCalledWith(
       [
         {

--- a/packages/sdk/test/providers/aws-resource-explorer-cache.test.ts
+++ b/packages/sdk/test/providers/aws-resource-explorer-cache.test.ts
@@ -5,7 +5,7 @@ import { STSClient } from '@aws-sdk/client-sts';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { createMemoryEvidenceCacheStore } from '../../src/evidence-cache.js';
 import * as clientModule from '../../src/providers/aws/client.js';
-import { withAwsEvidenceCache } from '../../src/providers/aws/evidence.js';
+import { getAwsEvidenceProvenance, withAwsEvidenceCache } from '../../src/providers/aws/evidence.js';
 import { getAwsExecutionSignal, withAwsDiscoveryExecution } from '../../src/providers/aws/execution.js';
 import { buildAwsDiscoveryCatalog, listAwsResourcesByFilter } from '../../src/providers/aws/resource-explorer.js';
 
@@ -24,6 +24,85 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   rmSync(admissionDirectory, { recursive: true, force: true });
+});
+
+it.each([false, true])('releases complete types before unrelated packed plans finish (cache: %s)', async (cached) => {
+  vi.spyOn(STSClient.prototype, 'send').mockResolvedValue({
+    Account: '123456789012',
+    Arn: 'arn:aws:iam::123456789012:user/test',
+    UserId: 'test',
+  } as never);
+  const firstType = `ec2:a${'a'.repeat(1100)}`;
+  const secondType = `ec2:z${'z'.repeat(1100)}`;
+  const pagination = Promise.withResolvers<void>();
+  const unrelated = Promise.withResolvers<void>();
+  const startedPagination = Promise.withResolvers<void>();
+  const startedUnrelated = Promise.withResolvers<void>();
+  let resourceLists = 0;
+  vi.spyOn(clientModule, 'createResourceExplorerClient').mockImplementation(
+    () =>
+      ({
+        send: vi.fn(async (command) => {
+          if (command.input.Regions) return { Indexes: [{ Region: 'eu-west-1', Type: 'AGGREGATOR' }] };
+          if (command.input.Filters) {
+            resourceLists += 1;
+            if (command.input.Filters.FilterString.includes(secondType)) {
+              startedUnrelated.resolve();
+              await unrelated.promise;
+              return { Resources: [] };
+            }
+            if (!command.input.NextToken) return { Resources: [], NextToken: 'last-page' };
+            startedPagination.resolve();
+            await pagination.promise;
+            return {
+              Resources: [
+                {
+                  Arn: 'arn:aws:ec2:eu-west-1:123456789012:instance/example',
+                  OwningAccountId: '123456789012',
+                  Region: 'eu-west-1',
+                  Service: 'ec2',
+                  ResourceType: firstType,
+                },
+              ],
+            };
+          }
+          return { ViewArn: 'view', View: { Filters: { FilterString: '' } } };
+        }),
+      }) as never,
+  );
+  const cache = { store: createMemoryEvidenceCacheStore(), authorizationContext: 'test-policy-v1' };
+  const target = { mode: 'region' as const, region: 'eu-west-1' };
+  const ready = vi.fn((resourceType, catalog) => {
+    expect(catalog).toMatchObject({ searchRegion: 'eu-west-1', indexType: 'AGGREGATOR', viewArn: 'view' });
+    if (cached)
+      expect(getAwsEvidenceProvenance()).toContainEqual(
+        expect.objectContaining({ datasetKey: `catalog:${resourceType}`, complete: true }),
+      );
+  });
+  const collect = () => buildAwsDiscoveryCatalog(target, [firstType, secondType], { onResourceTypeReady: ready });
+  const run = clientModule.withAwsClientCredentials({ accessKeyId: 'SYNTHETIC', secretAccessKey: 'SYNTHETIC' }, () =>
+    withAwsDiscoveryExecution({}, () => (cached ? withAwsEvidenceCache({ cache, target }, collect) : collect())),
+  );
+  try {
+    await startedPagination.promise;
+    expect(ready).not.toHaveBeenCalled();
+    pagination.resolve();
+    await startedUnrelated.promise;
+    await vi.waitFor(() => expect(ready).toHaveBeenCalledTimes(1));
+    expect(ready.mock.calls[0]).toEqual([
+      firstType,
+      expect.objectContaining({ resources: [expect.objectContaining({ resourceType: firstType })] }),
+    ]);
+    unrelated.resolve();
+    expect((await run).resources).toHaveLength(1);
+    expect(ready).toHaveBeenCalledTimes(2);
+    expect(ready.mock.calls[1]).toEqual([secondType, expect.objectContaining({ resources: [] })]);
+    expect(resourceLists).toBe(3);
+  } finally {
+    pagination.resolve();
+    unrelated.resolve();
+    await run;
+  }
 });
 
 it('reuses each catalog resource type across scans while checking the current view', { timeout: 30_000 }, async () => {
@@ -220,17 +299,21 @@ it.each([
   );
   const cache = { store: createMemoryEvidenceCacheStore(), authorizationContext: 'test-policy-v1' };
   const target = { mode: 'region' as const, region: 'eu-west-1' };
-  const scan = (types: string[], signal: AbortSignal) =>
+  const scan = (types: string[], signal: AbortSignal, onResourceTypeReady: ReturnType<typeof vi.fn>) =>
     clientModule.withAwsClientCredentials({ accessKeyId: 'SYNTHETIC', secretAccessKey: 'SYNTHETIC' }, () =>
       withAwsDiscoveryExecution({ signal }, () =>
-        withAwsEvidenceCache({ cache, target }, () => buildAwsDiscoveryCatalog(target, types)),
+        withAwsEvidenceCache({ cache, target }, () => buildAwsDiscoveryCatalog(target, types, { onResourceTypeReady })),
       ),
     );
   const firstController = new AbortController();
   const lastController = new AbortController();
-  const first = scan(['ec2:volume', 'ec2:instance'], firstController.signal).catch((error: unknown) => error);
+  const firstReady = vi.fn();
+  const lastReady = vi.fn();
+  const first = scan(['ec2:volume', 'ec2:instance'], firstController.signal, firstReady).catch(
+    (error: unknown) => error,
+  );
   await batchStarted;
-  const last = scan(['ec2:instance'], lastController.signal).catch((error: unknown) => error);
+  const last = scan(['ec2:instance'], lastController.signal, lastReady).catch((error: unknown) => error);
   try {
     await vi.waitFor(() => expect(viewRequests).toBe(2));
     // Let the second scan complete its cache probe and attach to the type flight.
@@ -242,11 +325,14 @@ it.each([
       lastController.abort(new Error('last caller cancelled'));
       expect(await last).toMatchObject({ message: 'last caller cancelled' });
       await vi.waitFor(() => expect(batchSignal?.aborted).toBe(true));
+      expect(lastReady).not.toHaveBeenCalled();
     } else {
       releaseBatch();
       expect(await last).toMatchObject({ resources: [{ resourceType: 'ec2:instance' }] });
+      expect(lastReady).toHaveBeenCalledOnce();
     }
     expect(resourceLists).toBe(1);
+    expect(firstReady).not.toHaveBeenCalled();
   } finally {
     releaseBatch();
     await Promise.all([first, last]);

--- a/packages/sdk/test/providers/aws-resource-explorer.test.ts
+++ b/packages/sdk/test/providers/aws-resource-explorer.test.ts
@@ -14,6 +14,48 @@ describe('resource explorer discovery', () => {
     vi.restoreAllMocks();
   });
 
+  it('waits for every selected region before reporting an empty resource type scope', async () => {
+    vi.spyOn(clientModule, 'listEnabledAwsRegions').mockResolvedValue(['eu-west-1', 'eu-central-1']);
+    const resourceType = `ec2:${'a'.repeat(2006)}`;
+    const lastRegion = Promise.withResolvers<void>();
+    const lastRegionStarted = Promise.withResolvers<void>();
+    let queries = 0;
+    vi.spyOn(clientModule, 'createResourceExplorerClient').mockImplementation(
+      ({ region }) =>
+        ({
+          send: vi.fn(async (command) => {
+            if (command.input.Regions)
+              return { Indexes: [{ Region: region, Type: region === 'eu-west-1' ? 'AGGREGATOR' : 'LOCAL' }] };
+            if (command.input.Filters) {
+              queries += 1;
+              expect(command.input.Filters.FilterString.length).toBeLessThanOrEqual(2048);
+              if (queries === 2) {
+                lastRegionStarted.resolve();
+                await lastRegion.promise;
+              }
+              return { Resources: [] };
+            }
+            return { ViewArn: 'view', View: { Filters: { FilterString: '' } } };
+          }),
+        }) as never,
+    );
+    const ready = vi.fn();
+    const run = buildAwsDiscoveryCatalog({ mode: 'regions', regions: ['eu-west-1', 'eu-central-1'] }, [resourceType], {
+      onResourceTypeReady: ready,
+    });
+    try {
+      await lastRegionStarted.promise;
+      expect(ready).not.toHaveBeenCalled();
+      lastRegion.resolve();
+      await run;
+      expect(ready).toHaveBeenCalledExactlyOnceWith(resourceType, expect.objectContaining({ resources: [] }));
+      expect(queries).toBe(2);
+    } finally {
+      lastRegion.resolve();
+      await run;
+    }
+  });
+
   it('checks other regions while a slow regional index lookup is still in flight', async () => {
     const regions = ['eu-west-1', 'eu-central-1', 'us-east-1'];
     vi.spyOn(clientModule, 'listEnabledAwsRegions').mockResolvedValue(regions);

--- a/packages/sdk/test/public-contracts.test.ts
+++ b/packages/sdk/test/public-contracts.test.ts
@@ -9,6 +9,7 @@ import type {
   AwsCostOptimizationHubRdsStorageUpgradeConfiguration,
   AwsCostOptimizationHubRdsUpgradeConfiguration,
   AwsCostOptimizationHubUpgradeRecommendation,
+  AwsDiscoveryProgressEvent,
   AwsEvidenceCacheOptions,
   AwsEvidenceProvenance,
   CloudBurnClient,
@@ -33,6 +34,28 @@ const reusableScan = async (
   return result.evidence;
 };
 void reusableScan;
+
+const consumeDiscoveryProgress = (event: AwsDiscoveryProgressEvent): number => {
+  switch (event.kind) {
+    case 'catalog':
+      return event.resourceCount;
+    case 'dataset':
+      return event.completedDatasets;
+    case 'rule': {
+      const status: RuleEvaluation['status'] = event.status;
+      const provisional: true = event.provisional;
+      // @ts-expect-error Progress can never claim to be an authoritative final result.
+      const final: false = event.provisional;
+      void [status, provisional, final];
+      return event.findingCount + event.findings.length + event.elapsedMs;
+    }
+    default: {
+      const exhaustive: never = event;
+      return exhaustive;
+    }
+  }
+};
+void consumeDiscoveryProgress;
 
 describe('public SDK contracts', () => {
   it('exports compiler-checked upgrade configurations, evaluation coverage and Config evidence', () => {


### PR DESCRIPTION
## Summary

Independent account checks can now collect evidence while Resource Explorer builds the catalog. Catalog-dependent datasets start when their declared resource types have finished pagination across the selected scope. A slow unrelated dataset no longer prevents a ready rule from reporting useful progress.

The SDK adds `kind: 'rule'` progress events with evaluated findings, status, counts, and elapsed time. These events are explicitly provisional: final evaluation still applies finding precedence and completed discovery availability. The CLI shows provisional status on interactive stderr and keeps structured stdout reserved for the final result. Cancellation still rejects the scan without a successful partial result.

Impact is significant because this changes discovery scheduling and adds a public progress-event variant. The merged cache and scheduler interfaces remain intact. Account-only evidence keys no longer depend on unrelated catalog metadata; existing mixed-scan entries may refresh once. Shared-file ownership was coordinated with #232, whose metric work is in #252.

## Diagram

```mermaid
flowchart LR
    Start[Start discovery] --> Catalog[Collect catalog scopes]
    Start --> Account[Collect independent account evidence]
    Catalog -->|Declared types fully paginated| Dataset[Collect dependent datasets]
    Account --> Ready[Rule evidence ready]
    Dataset --> Ready
    Ready --> Progress[Optional provisional rule event]
    Catalog --> Complete[All discovery settled]
    Account --> Complete
    Dataset --> Complete
    Complete --> Final[Final evaluation and finding precedence]
```

## Scope

- [x] `cloudburn` (cli)
- [x] `@cloudburn/sdk`
- [ ] `@cloudburn/rules`
- [x] docs/community files

## Release Notes

- [x] Added a `.changeset/*.md` file for published package changes
- [ ] No published package changes in this PR

## Verification

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm verify`

Validated on Node 24.18.0 and pnpm 11.15.1. All 14 verification tasks passed, including 1,046 SDK tests, 118 CLI tests, and 452 rule tests. Documentation checks and package-boundary checks passed. The simplifier review is complete.

Synthetic transport and evaluator regressions cover blocked catalogs, cached scope release, blocked unrelated hydration, incomplete pagination, optional evidence, native finding precedence, partial regions, later catalog failure, and cancellation after progress. In a synthetic blocked-hydration measurement, the first useful rule event arrived at 19 ms and final completion at 1,377 ms. These are separate timing observations, not a live AWS performance benchmark; no live AWS calls were made.

## Boundary Checks

- [x] No engine/parser/provider logic added to `@cloudburn/rules`
- [x] CLI delegates scan logic to SDK
- [x] README/CONTRIBUTING/docs updated when behavior changed

## Related Issues

Closes #233. Part of #235. Prerequisites #230 and #231 were verified merged through #249 and #251 before implementation. Coordinated with #232 / #252.
