### PR TITLE
fix(sdk): defer AWS imports for offline startup

### DIFF
--- a/.changeset/faster-command-startup.md
+++ b/.changeset/faster-command-startup.md
@@ -1,0 +1,5 @@
+---
+'cloudburn': patch
+---
+
+Reduce help, version, and static scan startup overhead by using the SDK's deferred AWS imports. Preserve command registration, output, option validation, and exit codes.

--- a/.changeset/quiet-live-imports.md
+++ b/.changeset/quiet-live-imports.md
@@ -1,0 +1,5 @@
+---
+'@cloudburn/sdk': patch
+---
+
+Defer live AWS imports until discovery operations need them. Static scans and package imports avoid AWS client and credential-provider loading, while preserving ESM/CommonJS exports, synchronous helpers, and managed credential and cancellation contexts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ adding, moving, or retiring durable documentation.
 ## Reference
 
 - [Commands](reference/commands.md) — supported root commands, Turbo filters, and side effects.
+- [Startup benchmarks](reference/startup-benchmarks.md): fresh-process CLI and SDK timing distributions and module loading.
 - [Generated files](reference/generated-files.md) — authoritative inputs and regeneration commands.
 - [Configuration schema](reference/config-schema.md) — fields, defaults, loading, validation, and merge behavior.
 - [AWS request scheduling](reference/aws-request-scheduling.md): quota scopes, local coordination, retries, environment overrides, and attempt telemetry.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -124,6 +124,14 @@ Keep the fixture expectations independent of implementation output. Normalize on
 
 `pnpm test:packages` builds and packs all three workspace packages, installs the archives into a temporary consumer project, then checks the installed CLI executable and SDK ESM/CommonJS exports with real scans. Nothing is published. Installation can access the public npm registry for runtime dependencies, so this suite is uncached and requires registry connectivity. The temporary consumer uses the repository-pinned pnpm version. The uncached task forwards `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` (including lowercase forms), and `NODE_EXTRA_CA_CERTS` through Turbo and into subprocesses for registry connectivity. It does not use AWS credentials or contact AWS.
 
+The built CLI template suite installs a module-resolution guard that rejects AWS SDK and Smithy dependencies, including
+credential providers. Help/version and static fixture scans must complete with the guard active. Installed ESM and CommonJS
+SDK consumers use the same guard to check static scans, synchronous region helpers, credential-scope Promise identity, and
+pre-cancelled discovery methods. A separate installed consumer drives real live chunks in both formats with synthetic HTTP
+responses, checking signed scoped credentials, findings, owned client disposal, and active cancellation. A module-resolution
+hook also cancels the first AWS import and checks that late import completion never resolves credentials. These structural
+checks enforce import independence without machine-specific timing gates.
+
 ## Runtime and type contracts
 
 Export tests should exercise values imported from the public package entry point. Constructing a typed object and

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -24,6 +24,14 @@ graph TD
   Estimate -.- EstimateFlags["--server url"]
 ```
 
+## Startup
+
+Command registration stays synchronous so help, option validation, and shell completion use the same complete command
+tree. The SDK defers live AWS imports behind its asynchronous discovery methods. Help, version, and static scans therefore
+avoid loading AWS clients or credential providers without changing command output or exit codes.
+[Startup benchmarks](../reference/startup-benchmarks.md) record fresh-process distributions for both module formats and
+representative commands.
+
 ## Formatter Pipeline
 
 ```mermaid

--- a/docs/architecture/sdk.md
+++ b/docs/architecture/sdk.md
@@ -23,6 +23,21 @@ generic rule metadata, and evaluated-resource projection; applications own produ
 mode config sets `failOn`, the facade evaluates it after the engine returns and attaches the threshold, qualifying
 count, and violation status to `ScanResult.policy`.
 
+### Module loading
+
+The SDK entry point keeps region validation and credential scoping in lightweight modules. Region validators remain
+synchronous, and `withAwsClientCredentials()` returns its callback's Promise without resolving credentials. Static scans,
+metadata access, and config loading do not import AWS clients or credential providers.
+
+Live facade methods load the AWS client, request, cache, and discovery modules inside managed execution. The deadline and
+cancellation signal cover that loading; each import continuation checks cancellation before starting work. Node may finish
+an import after cancellation, but its continuation cannot resolve credentials or dispatch requests. The shared credential
+scope remains available to lazily loaded clients, including calls wrapped in the public credential helper.
+
+Both ESM and CommonJS builds split the live graph into internal chunks. Package export paths and method signatures stay
+unchanged, and the published `dist/` directory includes those chunks. See the [startup benchmark](../reference/startup-benchmarks.md)
+for the measured cost and reproduction command.
+
 ## Engine Flow
 
 ```mermaid

--- a/docs/reference/generated-files.md
+++ b/docs/reference/generated-files.md
@@ -14,6 +14,7 @@ Coverage is opt-in; no root coverage script is defined. Select a workspace packa
 
 The CLI build starts at `packages/cloudburn/src/cli.ts` and publishes `dist/cli.js`. The SDK and rules builds start at
 their `src/index.ts` files and publish ESM, CommonJS, and declaration output described by their package manifests.
+The SDK also emits internal chunks for deferred live imports in both formats; publish the complete `dist/` directory.
 
 The reference pages for [rule IDs](rule-ids.md), [configuration](config-schema.md), and [finding shapes](finding-shape.md)
 are manually maintained from the code sources named at the top of each page. No generator currently updates them; change

--- a/docs/reference/startup-benchmarks.md
+++ b/docs/reference/startup-benchmarks.md
@@ -1,0 +1,76 @@
+# Startup benchmarks
+
+[The benchmark script](../../scripts/benchmark-startup.mjs) measures built CLI startup, static fixture scans, and both SDK
+module formats. It prints JSON to stdout for comparison between checkouts:
+
+```sh
+pnpm exec turbo run build --force
+node scripts/benchmark-startup.mjs 20 > /tmp/cloudburn-startup.json
+```
+
+The optional argument is the number of observations per scenario (default: 20; minimum: 15). Build the checkout before each
+run. Keep the Node version, machine, fixtures, sample count, and benchmark script identical when comparing changes.
+
+## Measurement method
+
+Each observation starts a fresh Node process and measures elapsed wall-clock time through successful exit, including
+process creation. Each scenario runs once before measurement to warm filesystem caches. Scenario order rotates between
+rounds. These are fresh-process observations with warm filesystem caches, not cold-disk measurements.
+
+The distribution reports milliseconds as minimum, p50, p90, and maximum. Percentiles use the nearest-rank method. Empty Node
+provides a process-startup baseline; its duration is not subtracted from other results. Static scans include parsing and
+evaluation, so their timings cover the complete command. Scan output must contain fixture findings and all commands must
+exit successfully for a run to complete.
+
+The Terraform and CloudFormation scenarios use the checked-in
+[EBS fixtures](../../packages/cloudburn/test/e2e/fixtures/ebs/) with `CLDBRN-AWS-EBS-1` enabled and JSON output. Each fixture
+contains a gp2 volume and a gp3 volume. SDK scenarios load the built `index.js` or `index.cjs` entry without creating a
+scanner. Package installation and export-map compatibility have separate package tests.
+
+Children run from a temporary directory with isolated home, config, and cache locations. Ambient `AWS_*` variables and
+`NODE_OPTIONS` are removed, AWS config and credential files point to absent files, and EC2 metadata credentials are disabled.
+The scenarios make no live AWS requests. The temporary files are removed when the benchmark exits.
+
+Module counts come from one additional, untimed process per scenario using Node's synchronous `registerHooks` load hook.
+The count includes distinct loaded file URLs and excludes built-ins and the instrumentation module. AWS file counts match
+`/@aws-sdk/`; AWS client counts are distinct `@aws-sdk/client-*` package names. Bundled source modules count as their emitted
+file, so these counts describe runtime file loading rather than TypeScript source-module counts. Instrumentation does not
+affect the reported timing distribution.
+
+## Issue 234 measurements
+
+The baseline was built from `779d55f66ff594844a2e7088b7ae2c4d92a81108` after cache and progress integration merged. The same
+script, fixtures, and 20 observations per scenario were used before and after the startup changes. Measurements ran on an
+Apple M4 with Node v24.18.0, Darwin 25.6.0, and arm64 architecture. The baseline completed on 2026-09-08 at 13:03 UTC; the
+updated build completed measurement at 13:06 UTC. Both builds used `pnpm exec turbo run build --force`.
+
+| Scenario             | Before min | Before p50 | Before p90 | Before max |
+| -------------------- | ---------: | ---------: | ---------: | ---------: |
+| Empty Node           |      20.59 |      22.85 |      24.85 |      29.73 |
+| CLI `--version`      |     362.98 |     389.65 |     437.91 |     585.68 |
+| CLI `--help`         |     364.66 |     382.21 |     458.17 |     608.08 |
+| Terraform scan       |     367.08 |     392.07 |     459.37 |     499.03 |
+| CloudFormation scan  |     363.06 |     397.63 |     437.14 |     445.79 |
+| SDK ESM import       |     359.36 |     382.74 |     421.46 |     442.10 |
+| SDK CommonJS require |     328.71 |     339.83 |     392.93 |     523.27 |
+
+| Scenario             | After min | After p50 | After p90 | After max | p50 reduction |
+| -------------------- | --------: | --------: | --------: | --------: | ------------: |
+| Empty Node           |     19.34 |     20.96 |     22.81 |     23.14 |          8.3% |
+| CLI `--version`      |    105.83 |    106.84 |    109.87 |    114.01 |         72.6% |
+| CLI `--help`         |    105.92 |    108.25 |    110.41 |    112.64 |         71.7% |
+| Terraform scan       |    108.93 |    112.22 |    118.50 |    138.01 |         71.4% |
+| CloudFormation scan  |    105.45 |    110.59 |    112.43 |    112.97 |         72.2% |
+| SDK ESM import       |     99.44 |    102.85 |    105.00 |    117.96 |         73.1% |
+| SDK CommonJS require |     98.34 |    101.35 |    106.67 |    117.74 |         70.2% |
+
+Before the change, every CLI and SDK scenario loaded all 29 AWS client packages: 54 AWS SDK files among 216 total files for
+the CLI and 207 for each SDK format. After the change, all measured scenarios loaded 0 AWS SDK files and 0 AWS client
+packages. Total loaded files fell to 129 for the CLI and 120 for each SDK format. Empty Node loaded 0 files in both runs.
+
+Median CLI metadata commands and static scans took about 71% to 73% less time in this run. The empty-process baseline also
+improved by 8.3%, which shows some run-to-run variation unrelated to application changes. The module observations establish
+that the AWS client graph was removed from these startup paths independently of timing noise.
+
+Timing distributions describe this machine and workload. They are evidence for this change, not CI speed gates or a
+cross-machine performance guarantee. Structural tests check that metadata and static paths avoid discovery dependencies.

--- a/packages/cloudburn/test/block-aws.cjs
+++ b/packages/cloudburn/test/block-aws.cjs
@@ -1,0 +1,11 @@
+// Offline commands must not load AWS clients or credential providers in either module format.
+const { registerHooks } = require('node:module');
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('@aws-sdk/') || specifier.startsWith('@smithy/')) {
+      throw new Error(`Offline command loaded an AWS dependency: ${specifier}`);
+    }
+    return nextResolve(specifier, context);
+  },
+});

--- a/packages/cloudburn/test/e2e/helpers.mjs
+++ b/packages/cloudburn/test/e2e/helpers.mjs
@@ -6,6 +6,7 @@ import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const cliPath = fileURLToPath(new URL('../../dist/cli.js', import.meta.url));
+const blockAwsPath = fileURLToPath(new URL('../block-aws.cjs', import.meta.url));
 const fixturesPath = fileURLToPath(new URL('./fixtures/', import.meta.url));
 
 /**
@@ -21,7 +22,7 @@ export const setupCli = (t, fixture) => {
   return {
     directory,
     run: (...args) => {
-      const result = spawnSync(process.execPath, [cliPath, ...args], {
+      const result = spawnSync(process.execPath, ['--require', blockAwsPath, cliPath, ...args], {
         cwd: directory,
         encoding: 'utf8',
         timeout: 15_000,

--- a/packages/cloudburn/test/e2e/startup.test.mjs
+++ b/packages/cloudburn/test/e2e/startup.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { setupCli } from './helpers.mjs';
+
+test('help and version work without loading AWS dependencies', (t) => {
+  const { run } = setupCli(t, 'healthy');
+  const { version } = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
+  const result = run('--version');
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, `${version}\n`);
+  assert.equal(result.stderr, '');
+
+  for (const command of [
+    [],
+    ['scan'],
+    ['discover'],
+    ['discover', 'init'],
+    ['discover', 'status'],
+    ['discover', 'supported-resource-types'],
+    ['rules'],
+    ['completion'],
+  ]) {
+    const help = run(...command, '--help');
+    assert.equal(help.status, 0, help.stderr);
+    assert.match(help.stdout, /Usage: cloudburn/);
+    assert.equal(help.stderr, '');
+  }
+});

--- a/packages/cloudburn/test/package/cancel-loading-consumer.cjs
+++ b/packages/cloudburn/test/package/cancel-loading-consumer.cjs
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const { registerHooks } = require('node:module');
+
+const main = async () => {
+  const sdk = process.argv[2] === 'module' ? await import('@cloudburn/sdk') : require('@cloudburn/sdk');
+  const controller = new AbortController();
+  const reason = new Error('Cancel while the first AWS module loads');
+  let intercepted = false;
+  let credentialCalls = 0;
+  const hook = registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (!intercepted && specifier.startsWith('@aws-sdk/client-')) {
+        intercepted = true;
+        // Abort at a real module-loading boundary before the live continuation can run.
+        controller.abort(reason);
+      }
+      return nextResolve(specifier, context);
+    },
+  });
+  const credentials = () => {
+    credentialCalls++;
+    throw new Error('Cancelled lazy loading must not resolve credentials');
+  };
+  await assert.rejects(
+    new sdk.CloudBurnClient().discover({
+      signal: controller.signal,
+      aws: { credentials },
+      cache: { mode: 'normal' },
+      target: { mode: 'region', region: 'eu-west-1' },
+      config: { discovery: { enabledRules: ['CLDBRN-AWS-COSTGUARDRAILS-2'] } },
+    }),
+    (error) => error === reason,
+  );
+  assert.equal(intercepted, true, 'Cancel during the first live import, before any credentials resolve.');
+  // Imports can finish after the facade rejects. Check again when pending module work has drained.
+  process.once('beforeExit', () => {
+    hook.deregister();
+    assert.equal(credentialCalls, 0);
+    process.stdout.write('ok\n');
+  });
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/cloudburn/test/package/discovery-consumer.cjs
+++ b/packages/cloudburn/test/package/discovery-consumer.cjs
@@ -1,0 +1,116 @@
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync } = require('node:fs');
+const { createRequire } = require('node:module');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { setTimeout: delay } = require('node:timers/promises');
+
+const main = async () => {
+  const sdk = process.argv[2] === 'module' ? await import('@cloudburn/sdk') : require('@cloudburn/sdk');
+  const dependency = createRequire(require.resolve('@cloudburn/sdk'));
+  const { EC2Client } = dependency('@aws-sdk/client-ec2');
+  const { STSClient } = dependency('@aws-sdk/client-sts');
+  const { CostExplorerClient } = dependency('@aws-sdk/client-cost-explorer');
+  const probe = new EC2Client({ region: 'eu-west-1' });
+  const transport = Object.getPrototypeOf(probe.config.requestHandler);
+  probe.destroy();
+  const originalHandle = transport.handle;
+  const originals = [STSClient, CostExplorerClient].map((Client) => [Client, Client.prototype.destroy]);
+  const destroyed = [];
+  const requests = [];
+  const signals = [];
+  const admissionDirectory = mkdtempSync(join(tmpdir(), 'cloudburn-consumer-discovery-'));
+  process.env.CLOUDBURN_AWS_ADMISSION_DIR = admissionDirectory;
+  process.env.AWS_REGION = 'eu-west-1';
+  process.env.AWS_EC2_METADATA_DISABLED = 'true';
+  let holdRequest = false;
+  const started = Promise.withResolvers();
+
+  for (const [Client, destroy] of originals) {
+    Client.prototype.destroy = function () {
+      destroyed.push(Client.name);
+      return destroy.call(this);
+    };
+  }
+  transport.handle = async (request, options) => {
+    const operation =
+      request.headers['x-amz-target']?.split('.').at(-1) ?? new URLSearchParams(String(request.body)).get('Action');
+    requests.push(operation);
+    assert.match(request.headers.authorization, /Credential=SCOPED\//);
+    assert.ok(options?.abortSignal, 'The emitted live chunks share the managed execution signal.');
+    signals.push(options.abortSignal);
+    if (holdRequest && operation === 'GetAnomalyMonitors') {
+      return new Promise((_resolve, reject) => {
+        options.abortSignal.addEventListener('abort', () => reject(options.abortSignal.reason), { once: true });
+        started.resolve();
+      });
+    }
+    if (operation === 'GetCallerIdentity') {
+      return {
+        response: {
+          statusCode: 200,
+          headers: { 'content-type': 'text/xml' },
+          body: Buffer.from(
+            '<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/"><GetCallerIdentityResult><Arn>arn:aws:iam::111111111111:user/synthetic</Arn><UserId>SYNTHETIC</UserId><Account>111111111111</Account></GetCallerIdentityResult></GetCallerIdentityResponse>',
+          ),
+        },
+      };
+    }
+    assert.equal(operation, 'GetAnomalyMonitors', `Unexpected offline AWS request: ${operation}`);
+    return {
+      response: {
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: Buffer.from('{"AnomalyMonitors":[]}'),
+      },
+    };
+  };
+
+  const discover = (signal) =>
+    sdk.withAwsClientCredentials({ accessKeyId: 'SCOPED', secretAccessKey: 'synthetic-key' }, () =>
+      new sdk.CloudBurnClient().discover({
+        signal,
+        timeoutMs: 10_000,
+        target: { mode: 'region', region: 'eu-west-1' },
+        config: { discovery: { enabledRules: ['CLDBRN-AWS-COSTGUARDRAILS-2'] } },
+      }),
+    );
+
+  try {
+    const result = await discover();
+    assert.deepEqual(
+      result.providers.flatMap((provider) => provider.rules.flatMap((rule) => rule.findings)),
+      [{ resourceId: '111111111111', accountId: '111111111111' }],
+    );
+    assert.deepEqual(requests, ['GetCallerIdentity', 'GetAnomalyMonitors']);
+    assert.deepEqual(destroyed.sort(), ['CostExplorerClient', 'STSClient']);
+    assert.ok(
+      signals.every((signal) => signal.aborted),
+      'Completed discovery disposes its execution.',
+    );
+
+    holdRequest = true;
+    const controller = new AbortController();
+    const reason = new Error('Installed consumer cancelled discovery');
+    const run = discover(controller.signal);
+    const rejected = assert.rejects(run, (error) => error === reason);
+    await Promise.race([started.promise, run]);
+    const requestCount = requests.length;
+    controller.abort(reason);
+    await rejected;
+    assert.ok(signals.every((signal) => signal.aborted));
+    assert.equal(destroyed.length, 4);
+    await delay(50);
+    assert.equal(requests.length, requestCount, 'Cancelled discovery must not dispatch later requests.');
+    process.stdout.write('ok\n');
+  } finally {
+    transport.handle = originalHandle;
+    for (const [Client, destroy] of originals) Client.prototype.destroy = destroy;
+    rmSync(admissionDirectory, { recursive: true, force: true });
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/cloudburn/test/package/install.test.mjs
+++ b/packages/cloudburn/test/package/install.test.mjs
@@ -77,6 +77,12 @@ before(() => {
   const installedSdk = createRequire(consumer.resolve('@cloudburn/sdk'));
   assert.equal(installedCli.resolve('@cloudburn/sdk'), consumer.resolve('@cloudburn/sdk'));
   assert.equal(installedSdk.resolve('@cloudburn/rules'), consumer.resolve('@cloudburn/rules'));
+  copyFileSync(
+    new URL('./cancel-loading-consumer.cjs', import.meta.url),
+    join(directory, 'cancel-loading-consumer.cjs'),
+  );
+  copyFileSync(new URL('./discovery-consumer.cjs', import.meta.url), join(directory, 'discovery-consumer.cjs'));
+  copyFileSync(new URL('../block-aws.cjs', import.meta.url), join(directory, 'block-aws.cjs'));
   copyFileSync(new URL('../e2e/fixtures/ebs/terraform/main.tf', import.meta.url), join(directory, 'main.tf'));
   copyFileSync(
     new URL('../e2e/fixtures/ebs/cloudformation/template.yaml', import.meta.url),
@@ -110,14 +116,41 @@ test('the installed CLI scans Terraform through its installed dependencies', () 
 });
 
 for (const format of ['module', 'commonjs']) {
-  test(`the installed SDK ${format} export scans CloudFormation`, () => {
+  test(`the installed SDK ${format} cancels while its first AWS module loads`, () => {
+    const result = run(process.execPath, ['cancel-loading-consumer.cjs', format], directory);
+    assert.equal(result.stdout, 'ok\n');
+    assert.equal(result.stderr, '');
+  });
+
+  test(`the installed SDK ${format} live chunks retain credentials, disposal, and cancellation`, () => {
+    const result = run(process.execPath, ['discovery-consumer.cjs', format], directory);
+    assert.equal(result.stdout, 'ok\n');
+    assert.equal(result.stderr, '');
+  });
+
+  test(`the installed SDK ${format} export keeps synchronous helpers and scans without AWS imports`, () => {
     const load = format === 'module' ? "await import('@cloudburn/sdk')" : "require('@cloudburn/sdk')";
     const source = `(async () => {
-      const { CloudBurnClient } = ${load};
-      const result = await new CloudBurnClient().scanStatic('template.yaml', { iac: { enabledRules: ['CLDBRN-AWS-EBS-1'] } });
+      const assert = ${format === 'module' ? "await import('node:assert/strict')" : "require('node:assert/strict')"};
+      const { CloudBurnClient, assertValidAwsRegion, assertSupportedAwsRegion, withAwsClientCredentials } = ${load};
+      assert.equal(assertValidAwsRegion('eu-west-1'), 'eu-west-1');
+      assert.equal(assertSupportedAwsRegion('us-east-1'), 'us-east-1');
+      assert.throws(() => assertSupportedAwsRegion('bad-region'), /Invalid AWS region/);
+      const value = Promise.resolve('scoped');
+      assert.equal(withAwsClientCredentials(() => { throw new Error('Credentials must stay unresolved'); }, () => value), value);
+      const scanner = new CloudBurnClient();
+      const reason = new Error('cancel before live modules load');
+      for (const operation of ['discover', 'getDiscoveryStatus', 'initializeDiscovery', 'listSupportedDiscoveryResourceTypes']) {
+        await assert.rejects(scanner[operation]({ signal: AbortSignal.abort(reason) }), error => error === reason);
+      }
+      const result = await scanner.scanStatic('template.yaml', { iac: { enabledRules: ['CLDBRN-AWS-EBS-1'] } });
       process.stdout.write(JSON.stringify(result.providers.flatMap(p => p.rules.flatMap(r => r.findings))));
     })().catch(error => { console.error(error); process.exitCode = 1; });`;
-    const result = run(process.execPath, ['--input-type', format, '--eval', source], directory);
+    const result = run(
+      process.execPath,
+      ['--require', './block-aws.cjs', '--input-type', format, '--eval', source],
+      directory,
+    );
     assert.equal(result.stderr, '');
     assert.deepEqual(JSON.parse(result.stdout), [
       { resourceId: 'Legacy', location: { path: 'template.yaml', line: 6, column: 7 } },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -16,13 +16,9 @@ export type {
 export { createEvidenceCache, createMemoryEvidenceCacheStore } from './evidence-cache.js';
 export { parseIaC } from './parsers/index.js';
 export { evaluateScanPolicy } from './policy.js';
-export {
-  type AwsClientCredentials,
-  assertSupportedAwsRegion,
-  assertValidAwsRegion,
-  withAwsClientCredentials,
-} from './providers/aws/client.js';
+export { type AwsClientCredentials, withAwsClientCredentials } from './providers/aws/credentials.js';
 export { isAwsDiscoveryErrorCode } from './providers/aws/errors.js';
+export { assertSupportedAwsRegion, assertValidAwsRegion } from './providers/aws/regions.js';
 export { CloudBurnClient } from './scanner.js';
 export type {
   AwsCloudFrontDistribution,

--- a/packages/sdk/src/providers/aws/client.ts
+++ b/packages/sdk/src/providers/aws/client.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { ApplicationAutoScalingClient } from '@aws-sdk/client-application-auto-scaling';
 import { BudgetsClient } from '@aws-sdk/client-budgets';
 import { CloudFrontClient } from '@aws-sdk/client-cloudfront';
@@ -28,36 +27,19 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { SageMakerClient } from '@aws-sdk/client-sagemaker';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
-import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@aws-sdk/types';
-import { AwsDiscoveryError } from './errors.js';
+import type { AwsCredentialIdentity } from '@aws-sdk/types';
+import { resolveAwsClientCredentials } from './credentials.js';
 import { getAwsClient, memoizeAwsExecution } from './execution.js';
+import { type AwsRegion, assertValidAwsRegion } from './regions.js';
 import { runAwsRequest, withAwsServiceCallBudget } from './request.js';
 
-export type AwsClientCredentials = AwsCredentialIdentity | AwsCredentialIdentityProvider;
+export { type AwsClientCredentials, withAwsClientCredentials } from './credentials.js';
+export { AWS_REGIONS, type AwsRegion, assertSupportedAwsRegion, assertValidAwsRegion } from './regions.js';
 
 export type AwsClientConfig = {
   region?: string;
 };
 
-const awsClientCredentialsContext = new AsyncLocalStorage<{ credentials?: AwsClientCredentials }>();
-
-/**
- * Runs a callback with ambient AWS credentials applied to every AWS client
- * created inside it, without requiring each call site to thread credentials.
- *
- * @param credentials - Credentials or credential provider to scope to the callback.
- * @param fn - Callback whose AWS client constructions should use the credentials.
- * @returns The callback result.
- */
-export const withAwsClientCredentials = <T>(
-  credentials: AwsClientCredentials | undefined,
-  fn: () => Promise<T>,
-): Promise<T> => awsClientCredentialsContext.run({ credentials }, fn);
-
-const resolveAwsClientCredentials = (): AwsClientCredentials | undefined =>
-  awsClientCredentialsContext.getStore()?.credentials;
-
-const AWS_REGION_PATTERN = /^[a-z]{2}(?:-[a-z0-9]+)+-\d+$/;
 const AWS_GLOBAL_CONTROL_REGION = 'us-east-1';
 const AWS_CLIENT_MAX_ATTEMPTS = 3;
 const AWS_ROUTE53_CLIENT_MAX_ATTEMPTS = 1;
@@ -77,82 +59,6 @@ const baseAwsClientConfig = () => ({
   },
   retryMode: 'adaptive',
 });
-export const AWS_REGIONS = [
-  'af-south-1',
-  'ap-east-1',
-  'ap-east-2',
-  'ap-northeast-1',
-  'ap-northeast-2',
-  'ap-northeast-3',
-  'ap-south-1',
-  'ap-south-2',
-  'ap-southeast-1',
-  'ap-southeast-2',
-  'ap-southeast-3',
-  'ap-southeast-4',
-  'ap-southeast-5',
-  'ap-southeast-6',
-  'ap-southeast-7',
-  'ca-central-1',
-  'ca-west-1',
-  'eu-central-1',
-  'eu-central-2',
-  'eu-north-1',
-  'eu-south-1',
-  'eu-south-2',
-  'eu-west-1',
-  'eu-west-2',
-  'eu-west-3',
-  'il-central-1',
-  'me-central-1',
-  'me-south-1',
-  'mx-central-1',
-  'sa-east-1',
-  'us-east-1',
-  'us-east-2',
-  'us-west-1',
-  'us-west-2',
-] as const;
-
-export type AwsRegion = (typeof AWS_REGIONS)[number];
-const SUPPORTED_AWS_REGIONS_MESSAGE = AWS_REGIONS.join(', ');
-
-const assertAwsRegionShape = (region: string | undefined): string => {
-  if (!region || !AWS_REGION_PATTERN.test(region)) {
-    throw new AwsDiscoveryError(
-      'INVALID_AWS_REGION',
-      `Invalid AWS region '${region ?? ''}'. Use a valid AWS region name such as 'eu-central-1' or 'us-east-1'.`,
-    );
-  }
-
-  return region;
-};
-
-/**
- * Validates an AWS region string before it is used in clients or filters.
- *
- * @param region - AWS region to validate.
- * @returns The original region when valid.
- */
-export const assertValidAwsRegion = (region: string | undefined): AwsRegion =>
-  assertAwsRegionShape(region) as AwsRegion;
-
-/**
- * Validates that a CLI-supplied AWS region is one of the known supported regions.
- *
- * @param region - AWS region supplied by the caller.
- * @returns The original region when it is part of the supported region list.
- */
-export const assertSupportedAwsRegion = (region: string | undefined): AwsRegion => {
-  if (!region || !AWS_REGION_PATTERN.test(region) || !AWS_REGIONS.includes(region as AwsRegion)) {
-    throw new AwsDiscoveryError(
-      'INVALID_AWS_REGION',
-      `Invalid AWS region '${region ?? ''}'. Supported regions: ${SUPPORTED_AWS_REGIONS_MESSAGE}.`,
-    );
-  }
-
-  return region as AwsRegion;
-};
 
 /** Creates an AWS EC2 client for a specific region. */
 export const createEc2Client = (config: AwsClientConfig): EC2Client =>

--- a/packages/sdk/src/providers/aws/credentials.ts
+++ b/packages/sdk/src/providers/aws/credentials.ts
@@ -1,0 +1,26 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@aws-sdk/types';
+
+export type AwsClientCredentials = AwsCredentialIdentity | AwsCredentialIdentityProvider;
+
+const awsClientCredentialsContext = new AsyncLocalStorage<{ credentials?: AwsClientCredentials }>();
+
+/**
+ * Runs a callback with ambient AWS credentials applied to every AWS client
+ * created inside it, without requiring each call site to thread credentials.
+ *
+ * @param credentials - Credentials or credential provider to scope to the callback.
+ * @param fn - Callback whose AWS client constructions should use the credentials.
+ * @returns The callback result.
+ */
+export const withAwsClientCredentials = <T>(
+  credentials: AwsClientCredentials | undefined,
+  fn: () => Promise<T>,
+): Promise<T> => awsClientCredentialsContext.run({ credentials }, fn);
+
+/**
+ * Reads the credentials scoped to the current callback without resolving a provider.
+ * @returns The current credentials or provider, when supplied.
+ */
+export const resolveAwsClientCredentials = (): AwsClientCredentials | undefined =>
+  awsClientCredentialsContext.getStore()?.credentials;

--- a/packages/sdk/src/providers/aws/regions.ts
+++ b/packages/sdk/src/providers/aws/regions.ts
@@ -1,0 +1,79 @@
+import { AwsDiscoveryError } from './errors.js';
+
+const AWS_REGION_PATTERN = /^[a-z]{2}(?:-[a-z0-9]+)+-\d+$/;
+export const AWS_REGIONS = [
+  'af-south-1',
+  'ap-east-1',
+  'ap-east-2',
+  'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-northeast-3',
+  'ap-south-1',
+  'ap-south-2',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ap-southeast-3',
+  'ap-southeast-4',
+  'ap-southeast-5',
+  'ap-southeast-6',
+  'ap-southeast-7',
+  'ca-central-1',
+  'ca-west-1',
+  'eu-central-1',
+  'eu-central-2',
+  'eu-north-1',
+  'eu-south-1',
+  'eu-south-2',
+  'eu-west-1',
+  'eu-west-2',
+  'eu-west-3',
+  'il-central-1',
+  'me-central-1',
+  'me-south-1',
+  'mx-central-1',
+  'sa-east-1',
+  'us-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
+] as const;
+
+export type AwsRegion = (typeof AWS_REGIONS)[number];
+const SUPPORTED_AWS_REGIONS_MESSAGE = AWS_REGIONS.join(', ');
+
+const assertAwsRegionShape = (region: string | undefined): string => {
+  if (!region || !AWS_REGION_PATTERN.test(region)) {
+    throw new AwsDiscoveryError(
+      'INVALID_AWS_REGION',
+      `Invalid AWS region '${region ?? ''}'. Use a valid AWS region name such as 'eu-central-1' or 'us-east-1'.`,
+    );
+  }
+
+  return region;
+};
+
+/**
+ * Validates an AWS region string before it is used in clients or filters.
+ *
+ * @param region - AWS region to validate.
+ * @returns The original region when valid.
+ */
+export const assertValidAwsRegion = (region: string | undefined): AwsRegion =>
+  assertAwsRegionShape(region) as AwsRegion;
+
+/**
+ * Validates that a CLI-supplied AWS region is one of the known supported regions.
+ *
+ * @param region - AWS region supplied by the caller.
+ * @returns The original region when it is part of the supported region list.
+ */
+export const assertSupportedAwsRegion = (region: string | undefined): AwsRegion => {
+  if (!region || !AWS_REGION_PATTERN.test(region) || !AWS_REGIONS.includes(region as AwsRegion)) {
+    throw new AwsDiscoveryError(
+      'INVALID_AWS_REGION',
+      `Invalid AWS region '${region ?? ''}'. Supported regions: ${SUPPORTED_AWS_REGIONS_MESSAGE}.`,
+    );
+  }
+
+  return region as AwsRegion;
+};

--- a/packages/sdk/src/scanner.ts
+++ b/packages/sdk/src/scanner.ts
@@ -1,19 +1,11 @@
 import { loadConfig } from './config/loader.js';
 import { mergeConfig } from './config/merge.js';
 import { emitDebugLog } from './debug.js';
-import { runLiveScan } from './engine/run-live.js';
 import { runStaticScan } from './engine/run-static.js';
 import { createMemoryEvidenceCacheStore, type EvidenceCacheStore } from './evidence-cache.js';
 import { evaluateScanPolicy } from './policy.js';
-import { resolveAwsAccountId, resolveCurrentAwsRegion, withAwsClientCredentials } from './providers/aws/client.js';
-import {
-  getAwsDiscoveryStatus,
-  initializeAwsDiscovery,
-  listSupportedAwsResourceTypes,
-} from './providers/aws/discovery.js';
-import { withAwsEvidenceCache } from './providers/aws/evidence.js';
-import { withAwsDiscoveryExecution } from './providers/aws/execution.js';
-import { withAwsServiceCallBudget } from './providers/aws/request.js';
+import { withAwsClientCredentials } from './providers/aws/credentials.js';
+import { throwIfAwsExecutionAborted, withAwsDiscoveryExecution } from './providers/aws/execution.js';
 import type {
   AwsDiscoveryExecutionOptions,
   AwsDiscoveryInitialization,
@@ -97,6 +89,8 @@ export class CloudBurnClient {
   ): Promise<ScanResult> {
     emitDebugLog(this.options?.debugLogger, 'sdk: starting live discovery scan');
     const run = async () => {
+      const { runLiveScan } = await import('./engine/run-live.js');
+      throwIfAwsExecutionAborted();
       const effectiveConfig = await this.getEffectiveConfig(options?.config, options?.configPath);
       const result = await runLiveScan(effectiveConfig, options?.target ?? { mode: 'current' }, {
         debugLogger: this.options?.debugLogger,
@@ -116,15 +110,18 @@ export class CloudBurnClient {
     const cacheSettings = cache && !cache.directory && !cache.store ? { ...cache, store: this.evidenceStore } : cache;
     return this.runDiscoveryOperation(
       options,
-      () =>
-        withAwsEvidenceCache(
+      async () => {
+        const { withAwsEvidenceCache } = await import('./providers/aws/evidence.js');
+        throwIfAwsExecutionAborted();
+        return withAwsEvidenceCache(
           {
             cache: cacheSettings,
             target: target ?? { mode: 'current' },
             debugLogger: this.options?.debugLogger,
           },
           run,
-        ),
+        );
+      },
       region,
     );
   }
@@ -137,7 +134,13 @@ export class CloudBurnClient {
   ): Promise<T> {
     return withAwsDiscoveryExecution(
       { signal: options?.signal, timeoutMs: options?.timeoutMs, debugLogger: this.options?.debugLogger },
-      () => {
+      async () => {
+        const [{ resolveAwsAccountId, resolveCurrentAwsRegion }, { withAwsServiceCallBudget }] = await Promise.all([
+          import('./providers/aws/client.js'),
+          import('./providers/aws/request.js'),
+        ]);
+        // Loading can outlive cancellation. Never start credentials or work after it settles.
+        throwIfAwsExecutionAborted();
         const execute = () =>
           withAwsServiceCallBudget(run, {
             resolveAccountId: async () => resolveAwsAccountId(region ?? (await resolveCurrentAwsRegion())),
@@ -160,10 +163,13 @@ export class CloudBurnClient {
 
     return this.runDiscoveryOperation(
       options,
-      () =>
-        this.options?.debugLogger === undefined
+      async () => {
+        const { getAwsDiscoveryStatus } = await import('./providers/aws/discovery.js');
+        throwIfAwsExecutionAborted();
+        return this.options?.debugLogger === undefined
           ? getAwsDiscoveryStatus(options?.region)
-          : getAwsDiscoveryStatus(options?.region, this.options.debugLogger),
+          : getAwsDiscoveryStatus(options?.region, this.options.debugLogger);
+      },
       options?.region,
     );
   }
@@ -181,10 +187,13 @@ export class CloudBurnClient {
 
     return this.runDiscoveryOperation(
       options,
-      () =>
-        this.options?.debugLogger === undefined
+      async () => {
+        const { initializeAwsDiscovery } = await import('./providers/aws/discovery.js');
+        throwIfAwsExecutionAborted();
+        return this.options?.debugLogger === undefined
           ? initializeAwsDiscovery(options?.region)
-          : initializeAwsDiscovery(options?.region, this.options.debugLogger),
+          : initializeAwsDiscovery(options?.region, this.options.debugLogger);
+      },
       options?.region,
     );
   }
@@ -199,7 +208,11 @@ export class CloudBurnClient {
     options?: AwsDiscoveryExecutionOptions,
   ): Promise<AwsSupportedResourceType[]> {
     emitDebugLog(this.options?.debugLogger, 'sdk: listing supported Resource Explorer resource types');
-    return this.runDiscoveryOperation(options, () => listSupportedAwsResourceTypes());
+    return this.runDiscoveryOperation(options, async () => {
+      const { listSupportedAwsResourceTypes } = await import('./providers/aws/discovery.js');
+      throwIfAwsExecutionAborted();
+      return listSupportedAwsResourceTypes();
+    });
   }
 
   /**

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   entry: { index: 'src/index.ts' },
   format: ['esm', 'cjs'],
   dts: true,
+  // Keep live imports deferred for CommonJS consumers as well as ESM.
+  splitting: true,
   target: 'node24',
   removeNodeProtocol: false,
   clean: true,

--- a/scripts/benchmark-startup.mjs
+++ b/scripts/benchmark-startup.mjs
@@ -1,0 +1,100 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpus, platform, release, tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// Build first. Each observation measures a fresh process through successful exit.
+const samples = Number(process.argv[2] ?? 20);
+if (!Number.isSafeInteger(samples) || samples < 15) {
+  throw new Error('Usage: node scripts/benchmark-startup.mjs [samples >= 15]');
+}
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const cli = join(root, 'packages/cloudburn/dist/cli.js');
+const sdk = join(root, 'packages/sdk/dist');
+const fixtures = join(root, 'packages/cloudburn/test/e2e/fixtures/ebs');
+const scenarios = [
+  { name: 'empty-node', args: ['--eval', ''] },
+  { name: 'cli-version', args: [cli, '--version'] },
+  { name: 'cli-help', args: [cli, '--help'] },
+  ...['terraform', 'cloudformation'].map((format) => ({
+    name: `scan-${format}`,
+    args: [cli, 'scan', join(fixtures, format), '--format', 'json', '--enabled-rules', 'CLDBRN-AWS-EBS-1'],
+  })),
+  { name: 'sdk-esm-import', args: ['--input-type=module', '--eval', `await import(${JSON.stringify(pathToFileURL(join(sdk, 'index.js')).href)})`] },
+  { name: 'sdk-cjs-require', args: ['--eval', `require(${JSON.stringify(join(sdk, 'index.cjs'))})`] },
+];
+const directory = mkdtempSync(join(tmpdir(), 'cloudburn-startup-'));
+const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('AWS_') && key !== 'NODE_OPTIONS'));
+Object.assign(env, {
+  HOME: directory,
+  XDG_CONFIG_HOME: directory,
+  XDG_CACHE_HOME: directory,
+  AWS_CONFIG_FILE: join(directory, 'absent-config'),
+  AWS_SHARED_CREDENTIALS_FILE: join(directory, 'absent-credentials'),
+  AWS_EC2_METADATA_DISABLED: 'true',
+  NO_COLOR: '1',
+});
+const hook = join(directory, 'measure-modules.mjs');
+const moduleOutput = join(directory, 'modules.json');
+writeFileSync(hook, `
+import { registerHooks } from 'node:module';
+import { writeFileSync } from 'node:fs';
+const loaded = new Set();
+registerHooks({ load(url, context, nextLoad) {
+  const result = nextLoad(url, context);
+  if (url.startsWith('file:')) loaded.add(url);
+  return result;
+}});
+process.on('exit', () => writeFileSync(${JSON.stringify(moduleOutput)}, JSON.stringify([...loaded])));
+`);
+
+function run(scenario, instrument = false) {
+  const start = performance.now();
+  const result = spawnSync(process.execPath, [...(instrument ? ['--import', hook] : []), ...scenario.args], {
+    cwd: directory, env, encoding: 'utf8', timeout: 30_000,
+  });
+  const elapsed = performance.now() - start;
+  if (result.error || result.status !== 0) {
+    throw new Error(`${scenario.name}: ${result.error?.message ?? result.stderr ?? result.status}`);
+  }
+  if (scenario.name.startsWith('scan-')) {
+    const output = JSON.parse(result.stdout);
+    if (!output.providers?.length) throw new Error(`${scenario.name}: expected fixture findings`);
+  }
+  return elapsed;
+}
+
+try {
+  const timings = new Map(scenarios.map((scenario) => [scenario.name, []]));
+  for (const scenario of scenarios) run(scenario);
+  // Rotate the first scenario each round to spread ordering effects.
+  for (let round = 0; round < samples; round++) {
+    for (let offset = 0; offset < scenarios.length; offset++) {
+      const scenario = scenarios[(round + offset) % scenarios.length];
+      timings.get(scenario.name).push(run(scenario));
+    }
+  }
+  const results = scenarios.map((scenario) => {
+    const values = timings.get(scenario.name).sort((a, b) => a - b);
+    const at = (quantile) => Number(values[Math.max(0, Math.ceil(values.length * quantile) - 1)].toFixed(2));
+    // Instrumentation is deliberately excluded from wall-clock observations.
+    run(scenario, true);
+    const modules = JSON.parse(readFileSync(moduleOutput, 'utf8'));
+    const awsModules = modules.filter((url) => url.includes('/@aws-sdk/'));
+    const awsClients = [...new Set(awsModules.flatMap((url) => url.match(/\/@aws-sdk\/(client-[^/]+)/)?.[1] ?? []))].sort();
+    return {
+      name: scenario.name,
+      milliseconds: { min: at(0), p50: at(0.5), p90: at(0.9), max: at(1) },
+      modules: { files: modules.length, awsFiles: awsModules.length, awsClients },
+    };
+  });
+  console.log(JSON.stringify({
+    measuredAt: new Date().toISOString(),
+    runtime: { node: process.version, platform: platform(), release: release(), arch: process.arch, cpu: cpus()[0]?.model },
+    samples, warmupsPerScenario: 1, results,
+  }, null, 2));
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

CLI help/version and static scans loaded all 29 AWS client packages through the SDK facade and its public region/credential helpers. Move the lightweight helpers out of the client module and load the live graph inside managed discovery execution. Keep synchronous command registration, public exports, ESM/CommonJS consumers, and credential scope behavior intact.

Both SDK formats now emit internal lazy chunks. Every import continuation checks cancellation before credentials or requests can start. Cache and request-scheduler behavior stays unchanged.

Built from `origin/main` at `779d55f`, after managed execution (#249), cache (#251), and progress (#253) merged. Fixes #234.

### Startup evidence

Same machine, Node v24.18.0, pnpm 11.15.1, forced fresh builds, 20 fresh processes per scenario, 1 warmup, rotating scenario order. Times below are medians in milliseconds; [the benchmark reference](https://github.com/towardsthecloud/cloudburn/blob/1ebc866/docs/reference/startup-benchmarks.md) includes min/p50/p90/max distributions and reproduction instructions.

| Scenario | Before | After |
| --- | ---: | ---: |
| Empty Node | 22.85 | 20.96 |
| CLI `--version` | 389.65 | 106.84 |
| CLI `--help` | 382.21 | 108.25 |
| Terraform scan | 392.07 | 112.22 |
| CloudFormation scan | 397.63 | 110.59 |
| SDK ESM import | 382.74 | 102.85 |
| SDK CommonJS require | 339.83 | 101.35 |

All measured offline paths went from 29 AWS client packages / 54 AWS SDK files to zero. These timings describe this machine with warm filesystem caches, not a cross-machine speed guarantee or CI timing gate.

### Impact and compatibility

Marked `impact:significant` because this changes module loading and packaged chunks used by every SDK consumer and relocates the shared credential context. Public signatures, export paths, callback Promise identity, synchronous region validation, CLI output, and exit behavior remain unchanged. First live use pays the deferred import cost within its existing deadline; Node can finish loading after cancellation, but the cancelled operation cannot continue to credential resolution or requests.

## Scope

- [x] `cloudburn` (cli)
- [x] `@cloudburn/sdk`
- [ ] `@cloudburn/rules`
- [x] docs/community files

## Release Notes

- [x] Added a `.changeset/*.md` file for published package changes
- [ ] No published package changes in this PR

## Verification

- [x] `pnpm lint` (via `pnpm verify`)
- [x] `pnpm typecheck` (via `pnpm verify`)
- [x] `pnpm test` (all suites via `pnpm verify`)
- [x] `pnpm build` and forced builds before/after measurement
- [x] `pnpm verify` (14 tasks passed in this isolated checkout)

Red-green evidence: built CLI and installed ESM/CommonJS tests rejected eager AWS imports before the change and passed afterward. Module-resolution guards now cover help/version, Terraform/CloudFormation scans, synchronous helpers, and pre-cancelled live operations. Installed consumers also cancel during their first AWS import and run real live chunks with synthetic HTTP responses to verify signed scoped credentials, findings, disposal, and active cancellation. No live AWS calls were made.

Focused SDK validation: 96 tests passed across scanner, HTTP discovery integration, cancellation, and credential scope. Full validation includes 1,074 SDK tests, 452 rules tests, 118 CLI source tests, 15 built CLI tests, 10 installed-package tests, and 14 documentation tests. Simplifier and correctness review completed.

## Boundary Checks

- [x] No engine/parser/provider logic added to `@cloudburn/rules`
- [x] CLI delegates scan logic to SDK
- [x] README/CONTRIBUTING/docs updated when behavior changed

## Related Issues

Closes #234. Parent tracking issue: #235. Prerequisite integrations: #230, #231, #233.
